### PR TITLE
Feature dorpdown amount data

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,18 +71,21 @@ android {
             versionName "2.1.4"
             minSdkVersion 15
             targetSdkVersion 23
+            buildConfigField "boolean", "loginDataDownloadPeriod", "true"
         }
         hnqis {
             applicationId "org.eyeseetea.malariacare.hnqis_bb"
             versionName "1.1.3"
             minSdkVersion 15
             targetSdkVersion 23
+            buildConfigField "boolean", "loginDataDownloadPeriod", "false"
         }
         surveillance {
             applicationId "org.eyeseetea.malariacare.surveillance_bb"
             versionName "5.0.0"
             minSdkVersion 15
             targetSdkVersion 23
+            buildConfigField "boolean", "loginDataDownloadPeriod", "false"
         }
     }
     lintOptions {

--- a/app/src/eds/res/values/strings.xml
+++ b/app/src/eds/res/values/strings.xml
@@ -22,4 +22,9 @@
     <string name="create_info_ok">Start Assessment</string>
     <string name="assessment_sent_title_header">Complete Assessment(s)</string>
     <string name="dialog_info_push_empty_survey">Empty surveys cannot be pushed</string>
+    <string name="download">"Download:"</string>
+    <string name="no_data">"no data"</string>
+    <string name="last_6_days">"Latest 6 days"</string>
+    <string name="last_6_weeks">"Latest 6 weeks"</string>
+    <string name="last_6_months">"Latest 6 months"</string>
 </resources>

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/importer/PullController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/importer/PullController.java
@@ -22,8 +22,6 @@ package org.eyeseetea.malariacare.database.iomodules.dhis.importer;
 import android.content.Context;
 import android.util.Log;
 
-import com.raizlabs.android.dbflow.runtime.transaction.process.ProcessModelInfo;
-import com.raizlabs.android.dbflow.runtime.transaction.process.SaveModelTransaction;
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.squareup.otto.Subscribe;
 
@@ -33,7 +31,8 @@ import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.DataEle
 import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.EventExtended;
 import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.OptionSetExtended;
 import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.OrganisationUnitExtended;
-import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.OrganisationUnitLevelExtended;
+import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models
+        .OrganisationUnitLevelExtended;
 import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.ProgramExtended;
 import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.UserAccountExtended;
 import org.eyeseetea.malariacare.database.model.CompositeScore;
@@ -43,7 +42,6 @@ import org.eyeseetea.malariacare.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.database.utils.Session;
 import org.eyeseetea.malariacare.database.utils.planning.SurveyPlanner;
 import org.eyeseetea.malariacare.layout.dashboard.builder.AppSettingsBuilder;
-import org.eyeseetea.malariacare.layout.dashboard.config.AppSettings;
 import org.hisp.dhis.android.sdk.controllers.DhisService;
 import org.hisp.dhis.android.sdk.controllers.LoadingController;
 import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
@@ -59,7 +57,6 @@ import org.hisp.dhis.android.sdk.persistence.models.OrganisationUnit;
 import org.hisp.dhis.android.sdk.persistence.models.OrganisationUnitLevel;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramStage;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramStageDataElement;
-import org.hisp.dhis.android.sdk.persistence.preferences.AppPreferences;
 import org.hisp.dhis.android.sdk.persistence.preferences.ResourceType;
 import org.hisp.dhis.android.sdk.utils.api.ProgramType;
 import org.hisp.dhis.android.sdk.utils.log.LogMessage;
@@ -69,6 +66,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -158,10 +156,11 @@ public class PullController {
             //Enabling resources to pull
             enableMetaDataFlags();
             //Delete previous metadata
-            TrackerController.setMaxEvents(PreferencesState.getInstance().getMaxEvents());
-            Calendar month = Calendar.getInstance();
-            month.add(Calendar.MONTH, -NUMBER_OF_MONTHS);
-            TrackerController.setStartDate(EventExtended.format(month.getTime(),EventExtended.AMERICAN_DATE_FORMAT));
+            TrackerController.setMaxEvents(getMaxEvents());
+            TrackerController.setStartDate(EventExtended.format(getStartDate().getTime(),
+                    EventExtended.AMERICAN_DATE_FORMAT));
+            TrackerController.setEndDate(EventExtended.format(Calendar.getInstance().getTime(),
+                    EventExtended.AMERICAN_DATE_FORMAT));
             MetaDataController.setFullOrganisationUnitHierarchy(AppSettingsBuilder.isFullHierarchy());
             MetaDataController.clearMetaDataLoadedFlags();
             MetaDataController.wipe();
@@ -170,12 +169,7 @@ public class PullController {
             //Pull new metadata
             postProgress(context.getString(R.string.progress_pull_downloading));
             try {
-                if(AppSettingsBuilder.isDownloadOnlyLastEvents()){
-                    job = DhisService.loadLastData(context);
-                }
-                else{
                     job = DhisService.loadData(context);
-                }
             } catch (Exception ex) {
                 Log.e(TAG, "pullS: " + ex.getLocalizedMessage());
                 ex.printStackTrace();
@@ -185,6 +179,22 @@ public class PullController {
             unregister();
             postException(ex);
         }
+    }
+
+
+    private Calendar getStartDate() {
+        Calendar startDate = Calendar.getInstance();
+        Date savedStartDate = PreferencesState.getInstance().getDateStarDateLimitFilter();
+        if (savedStartDate == null) {
+            startDate.add(Calendar.MONTH, -NUMBER_OF_MONTHS);
+        } else {
+            startDate.setTime(savedStartDate);
+        }
+        return startDate;
+    }
+
+    private int getMaxEvents() {
+        return PreferencesState.getInstance().getMaxEvents();
     }
 
     /**

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/importer/PullController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/importer/PullController.java
@@ -161,6 +161,7 @@ public class PullController {
                     EventExtended.AMERICAN_DATE_FORMAT));
             TrackerController.setEndDate(EventExtended.format(Calendar.getInstance().getTime(),
                     EventExtended.AMERICAN_DATE_FORMAT));
+            TrackerController.setDownloadData(!isNoData());
             MetaDataController.setFullOrganisationUnitHierarchy(AppSettingsBuilder.isFullHierarchy());
             MetaDataController.clearMetaDataLoadedFlags();
             MetaDataController.wipe();
@@ -169,7 +170,11 @@ public class PullController {
             //Pull new metadata
             postProgress(context.getString(R.string.progress_pull_downloading));
             try {
-                    job = DhisService.loadData(context);
+                    if (AppSettingsBuilder.isDownloadOnlyLastEvents()) {
+                        job = DhisService.loadLastData(context);
+                    } else {
+                        job = DhisService.loadData(context);
+                    }
             } catch (Exception ex) {
                 Log.e(TAG, "pullS: " + ex.getLocalizedMessage());
                 ex.printStackTrace();
@@ -191,6 +196,10 @@ public class PullController {
             startDate.setTime(savedStartDate);
         }
         return startDate;
+    }
+
+    private boolean isNoData() {
+        return PreferencesState.getInstance().isNoDataDownload();
     }
 
     private int getMaxEvents() {

--- a/app/src/main/java/org/eyeseetea/malariacare/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/utils/PreferencesState.java
@@ -29,6 +29,7 @@ import android.util.Log;
 import org.eyeseetea.malariacare.DashboardActivity;
 import org.eyeseetea.malariacare.ProgressActivity;
 import org.eyeseetea.malariacare.R;
+import org.eyeseetea.malariacare.domain.entity.DateFilter;
 import org.eyeseetea.malariacare.utils.Constants;
 import org.eyeseetea.malariacare.layout.dashboard.builder.AppSettingsBuilder;
 import org.eyeseetea.malariacare.layout.dashboard.config.DashboardAdapter;
@@ -36,6 +37,8 @@ import org.eyeseetea.malariacare.layout.dashboard.config.DashboardListFilter;
 import org.eyeseetea.malariacare.layout.dashboard.config.DashboardOrientation;
 import org.eyeseetea.malariacare.layout.dashboard.config.DatabaseOriginType;
 
+import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -411,6 +414,28 @@ public class PreferencesState {
         prefEditor.putString(context.getResources().getString(namePreference),
                 value); // set your default value here (could be empty as well)
         prefEditor.apply(); // finally save changes
+    }
+
+    public Date getDateStarDateLimitFilter() {
+        DateFilter dateFilter = new DateFilter();
+
+        String dateLimit = getDataLimitedByDate();
+        if (dateLimit.isEmpty()) {
+            return null;
+        }
+        if (dateLimit.equals(getContext().getString(R.string.last_6_days))) {
+            dateFilter.setLast6Days(true);
+        } else if (dateLimit.equals(getContext().getString(R.string.last_6_weeks))) {
+            dateFilter.setLast6Weeks(true);
+        } else if (dateLimit.equals(getContext().getString(R.string.last_6_months))) {
+            dateFilter.setLast6Month(true);
+        }else if(dateLimit.equals(getContext().getString(R.string.no_data))){
+            dateFilter.setNoData(true);
+        }
+
+        Calendar calendar = Calendar.getInstance();
+        Date date = dateFilter.getStartFilterDate(calendar);
+        return date;
     }
 
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/utils/PreferencesState.java
@@ -30,12 +30,12 @@ import org.eyeseetea.malariacare.DashboardActivity;
 import org.eyeseetea.malariacare.ProgressActivity;
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.domain.entity.DateFilter;
-import org.eyeseetea.malariacare.utils.Constants;
 import org.eyeseetea.malariacare.layout.dashboard.builder.AppSettingsBuilder;
 import org.eyeseetea.malariacare.layout.dashboard.config.DashboardAdapter;
 import org.eyeseetea.malariacare.layout.dashboard.config.DashboardListFilter;
 import org.eyeseetea.malariacare.layout.dashboard.config.DashboardOrientation;
 import org.eyeseetea.malariacare.layout.dashboard.config.DatabaseOriginType;
+import org.eyeseetea.malariacare.utils.Constants;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -429,13 +429,19 @@ public class PreferencesState {
             dateFilter.setLast6Weeks(true);
         } else if (dateLimit.equals(getContext().getString(R.string.last_6_months))) {
             dateFilter.setLast6Month(true);
-        }else if(dateLimit.equals(getContext().getString(R.string.no_data))){
-            dateFilter.setNoData(true);
         }
 
         Calendar calendar = Calendar.getInstance();
         Date date = dateFilter.getStartFilterDate(calendar);
         return date;
+    }
+
+    public boolean isNoDataDownload() {
+        String dateLimit = getDataLimitedByDate();
+        if (dateLimit.equals(getContext().getString(R.string.no_data))) {
+            return true;
+        }
+        return false;
     }
 
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/utils/PreferencesState.java
@@ -390,4 +390,27 @@ public class PreferencesState {
         conf.locale = new Locale(languageCode);
         res.updateConfiguration(conf, dm);
     }
+
+    public String getDataLimitedByDate() {
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
+                instance.getContext());
+        return sharedPreferences.getString(
+                instance.getContext().getString(R.string.data_limited_by_date), "");
+    }
+
+    public void setDataLimitedByDate(String value) {
+        saveStringPreference(R.string.data_limited_by_date, value);
+    }
+
+    /**
+     * Saves a value into a preference
+     */
+    public void saveStringPreference(int namePreference, String value) {
+        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences.Editor prefEditor = sharedPref.edit(); // Get preference in editor mode
+        prefEditor.putString(context.getResources().getString(namePreference),
+                value); // set your default value here (could be empty as well)
+        prefEditor.apply(); // finally save changes
+    }
+
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/DateFilter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/DateFilter.java
@@ -1,0 +1,80 @@
+package org.eyeseetea.malariacare.domain.entity;
+
+import java.util.Calendar;
+import java.util.Date;
+
+public class DateFilter {
+    boolean all = true;
+    private boolean noData;
+    private boolean last6Days;
+    private boolean last6Weeks;
+    private boolean last6Month;
+
+    public boolean isNoData() {
+        return noData;
+    }
+
+    public void setNoData(boolean noData) {
+        all = false;
+        this.noData = noData;
+    }
+
+    //This filter include the current day
+    public boolean isLast6Days() {
+        return last6Days;
+    }
+
+    public void setLast6Days(boolean last6Days) {
+        all = false;
+        this.last6Days = last6Days;
+    }
+
+    //This filter include the current week
+    public boolean isLast6Weeks() {
+        return last6Weeks;
+    }
+
+    public void setLast6Weeks(boolean last6Weeks) {
+        all = false;
+        this.last6Weeks = last6Weeks;
+    }
+
+    //This filter ignore the current month
+    public boolean isLast6Month() {
+        return last6Month;
+    }
+
+    public void setLast6Month(boolean last6Month) {
+        all = false;
+        this.last6Month = last6Month;
+    }
+
+    public Date getStartFilterDate(Calendar calendar) {
+        if (isLast6Days()) {
+            calendar.add(Calendar.DAY_OF_YEAR, -5);
+        } else if (isLast6Weeks()) {
+            calendar.set(Calendar.DAY_OF_WEEK, calendar.getFirstDayOfWeek());
+            calendar.add(Calendar.WEEK_OF_YEAR, -5);
+        } else if (isLast6Month()) {
+            calendar.set(Calendar.DAY_OF_MONTH, 1);
+            calendar.add(Calendar.MONTH, -5);
+        } else if (isNoData()) {
+            return Calendar.getInstance().getTime();
+        }
+        clearTime(calendar);
+        return calendar.getTime();
+    }
+
+    /**
+     * Wipes off time info from date
+     *
+     * @return A new date without time data (00:00:00:000)
+     */
+    private Calendar clearTime(Calendar date) {
+        date.set(Calendar.HOUR_OF_DAY, 0);
+        date.set(Calendar.MINUTE, 0);
+        date.set(Calendar.SECOND, 0);
+        date.set(Calendar.MILLISECOND, 0);
+        return date;
+    }
+}

--- a/app/src/main/res/layout/login_spinner.xml
+++ b/app/src/main/res/layout/login_spinner.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/date_spinner_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:visibility="invisible"
+    android:padding="8dp">
+
+    <org.eyeseetea.malariacare.views.CustomTextView
+        android:id="@+id/data_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="34dp"
+        android:layout_marginBottom="1px"
+        android:drawablePadding="7dp"
+        android:gravity="center_vertical"
+        android:paddingLeft="7dp"
+        android:singleLine="true"
+        android:textSize="@dimen/medium_text_size"
+        app:tFontName="@string/regular_font_name" />
+
+    <Spinner
+        android:id="@+id/data_spinner"
+        android:layout_width="match_parent"
+        android:layout_height="34dp" />
+</LinearLayout>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -103,4 +103,5 @@
         <p>3. Run "git checkout". </p>]]>
     </string>
     <item name="language_code" translatable="false" type="string">language_code</item>
+    <string name="data_limited_by_date" translatable="false">data_limited_by_date</string>
     </resources>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2079 
* **Related pull-requests:** 

### :tophat: What is the goal?

Add a date filter in the login activity, to select the amount of data you want to download.

### :memo: How is it being implemented?
I add a spinner in the login activity, and  saving the selection in the shared preferences, then getting from it when starting the pull and configure the pull whit the saved values.

### :boom: How can it be tested?

- [x] **Use case 1:** Test login and pull
    - [x] make login in http://eds.jhpiegodb.org:8080 with ifoche_test.
    - [x] check the log, to check if the request are well made it (the start date and the end date filters are the correct).
    - [x] See the correct surveys downloaded in the app.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
