### PR TITLE
Showing always the entire asterisk in mandatory feedback questions.

### DIFF
--- a/app/src/hnqis/res/layout/feedback_question_row.xml
+++ b/app/src/hnqis/res/layout/feedback_question_row.xml
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content"
             android:layout_weight=".80">
 
-            <LinearLayout
+            <RelativeLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content">
 
@@ -41,6 +41,8 @@
                     android:id="@+id/feedback_question_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_toLeftOf="@+id/feedback_question_mandatory"
                     android:paddingBottom="5dip"
                     android:paddingLeft="10dip"
                     android:paddingTop="5dip"
@@ -53,12 +55,12 @@
                     android:id="@+id/feedback_question_mandatory"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:paddingLeft="5dp"
-                    android:paddingRight="5dp"
+                    android:layout_alignParentRight="true"
+                    android:paddingRight="15dp"
                     android:text="*"
                     android:visibility="invisible"
                     android:textColor="@color/black" />
-            </LinearLayout>
+            </RelativeLayout>
             <org.eyeseetea.malariacare.views.CustomTextView
                 android:id="@+id/feedback_uid"
                 android:layout_width="wrap_content"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2086   
* **Related pull-requests:** 

### :tophat: What is the goal?
Show always the entire asterisk in feedback questions. 

### :memo: How is it being implemented?
Changing the asterisk and question label container yo a relative layout and never cover the asterisk.

### :boom: How can it be tested?

- [x] **Use case 1:** Enter in a feedback video and go back from it.
    - [x] make login in http://clone.psi-mis.or with KEdemo1.
    - [x] got to feedback and select the program KE HNQIS Family Planning Long-...
    - [x] View a survey feedback and open mandatory questions to see if the asterisk is showing correctly.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
