### PR TITLE
Change the message in case inactive selection of pair OU/Health Area

### DIFF
--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -288,4 +288,5 @@ clínica"</string>
 <string name="improve_no_surveys">"No se completaron encuestas para la selección que ha realizado."</string>
 <string name="scheduled">Programado</string>
 <string name="reschedule_title_multiple_survey">"%1$d número de encuestas que se reprogramarán para la OU %2$s"</string>
+<string name="survey_not_assigned_facility">"Esta encuesta no está asignada a esta instalación. Por favor, selecciona otra encuesta."</string>
 </resources>

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -280,4 +280,5 @@ Mensuelle"</string>
     </string-array>
 <string name="scheduled">Prévu</string>
 <string name="reschedule_title_multiple_survey">"%1$d nombre d'enquêtes en cours de re-planification pour OU %2$s"</string>
+<string name="survey_not_assigned_facility">"Cette enquête n'est pas affectée à cette installation. Veuillez sélectionner une autre enquête."</string>
 </resources>

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -300,4 +300,5 @@
 <string name="improve_no_surveys">"គ្មានការស្ទង់មតិសម្រាប់ការជ្រើសរើសដែលអ្នកបានធ្វើទេ។"</string>
 <string name="scheduled">កំណត់ពេល</string>
 <string name="reschedule_title_multiple_survey">"ការស្ទង់មតិចំនួន %1$d ដែលត្រូវបានកំណត់ឡើងវិញសម្រាប់ OU %2$s"</string>
+<string name="survey_not_assigned_facility">"ការស្ទង់មតិនេះមិនត្រូវបានកំណត់ទៅកន្លែងនេះទេ។ សូមជ្រើសរើសការស្ទង់មតិផ្សេងទៀត។"</string>
 </resources>

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -295,4 +295,5 @@
 <string name="improve_no_surveys">"ບໍ່ມີການສໍາຫຼວດສໍາລັບການຄັດເລືອກທີ່ທ່ານໄດ້ເຮັດ."</string>
 <string name="scheduled">ກໍານົດເວລາ</string>
 <string name="reschedule_title_multiple_survey">"ຈໍານວນການສໍາຫຼວດຈໍານວນ %1$d ຖືກກໍານົດໄວ້ສໍາລັບ OU %2$s"</string>
+<string name="survey_not_assigned_facility">"ການສໍາຫຼວດນີ້ບໍ່ໄດ້ມອບຫມາຍໃຫ້ສະຖານທີ່ນີ້. ກະລຸນາເລືອກການສໍາຫຼວດອື່ນ."</string>
 </resources>

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -282,4 +282,5 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
     </string-array>
 <string name="scheduled">Agendado</string>
 <string name="reschedule_title_multiple_survey">"%1$d número de pesquisas sendo reprogramadas para OU %2$s"</string>
+<string name="survey_not_assigned_facility">"Esta pesquisa não está atribuída a essa facilidade. Por favor, selecione outra pesquisa."</string>
 </resources>

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -291,4 +291,5 @@ evaluation"</string>
 <string name="assess_no_surveys">"No active survey(s) at this time for the selection you have made. Click on + to start a new survey"</string>
 <string name="improve_no_surveys">"No survey(s) completed for the selection you have made."</string>
 <string name="scheduled">Scheduled</string>
+<string name="survey_not_assigned_facility">"This survey is not assigned to this facility. Please, select another survey."</string>
 </resources>

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
@@ -154,10 +154,13 @@ public class DashboardUnsentFragment extends ListFragment implements IModuleFrag
         || program.getName().equals(
                 PreferencesState.getInstance().getContext().getString(R.string.filter_all_org_assessments))){
             startButton.setVisibility(View.VISIBLE);
+            noSurveysText.setText(R.string.assess_no_surveys);
         }else if (survey != null || !OrgUnitProgramRelationDB.existProgramAndOrgUnitRelation(program.getId_program(), orgUnit.getId_org_unit())){
             startButton.setVisibility(View.INVISIBLE);
+            noSurveysText.setText(R.string.survey_not_assigned_facility);
         }else{
             startButton.setVisibility(View.VISIBLE);
+            noSurveysText.setText(R.string.assess_no_surveys);
         }
     }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2087   
* **Related pull-requests:** 

### :tophat: What is the goal?
Change the showing message if pair OU/Health is inactive.

### :memo: How is it being implemented?
Changing the showing message when the add button is hidden.

### :boom: How can it be tested?

- [x] **Use case 1:** Enter in a feedback video and go back from it.
    - [x] make login in http://clone.psi-mis.or with KEdemo1.
    - [x] got to new surveys tab an select KE HNQIS HIV  and _Test KE 3to see the original message.
    - [x] then change KE HNQIS HIV to KE HNQIS Hypertension to see the new one.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
