### PR TITLE
Change Na text color in feedback.

### DIFF
--- a/app/src/hnqis/res/values/colors.xml
+++ b/app/src/hnqis/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="high_score_color">#00cd00</color>
     <color name="medium_score_color">@color/assess_yellow</color>
     <color name="low_score_color">@color/darkRed</color>
+    <color name="na_text_color">@color/black</color>
 </resources>

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/feedback/QuestionFeedback.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/feedback/QuestionFeedback.java
@@ -209,7 +209,7 @@ public class QuestionFeedback implements Feedback {
     public int getColor() {
         int textColor;
         if (this.getOption() == null || this.getOption().isEmpty()) {
-            textColor = R.color.amber;
+            textColor = R.color.na_text_color;
         } else {
             textColor = (this.isPassed() && value != null && !this.value.getConflict()) ? R.color.green : R.color.red;
         }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2090    
* **Related pull-requests:** 

### :tophat: What is the goal?
Changing NA color from yellow to black.

### :memo: How is it being implemented?
Adding a new color and changing the old color for the new one.

### :boom: How can it be tested?

- [x] **Use case 1:** Enter in a feedback video and go back from it.
    - [ ] make login in http://clone.psi-mis.or with KEdemo1.
    - [ ] got to new survey and select the program KE HNQIS HIV and create a new survey.
    - [ ] press back button and complete it not filling anything.
    - [ ] got to feedback and see the survey feedback and open a question detail.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

![device-2018-08-09-174341](https://user-images.githubusercontent.com/24573727/43910113-357a1cde-9bfc-11e8-9d10-6d6642db87af.png)