### PR TITLE
Change pie scores in modal menu style.

### DIFF
--- a/app/src/hnqis/res/layout/modal_menu.xml
+++ b/app/src/hnqis/res/layout/modal_menu.xml
@@ -36,26 +36,13 @@
                 android:layout_toRightOf="@+id/pie_chart"
                 android:orientation="vertical">
 
-                <RelativeLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
 
-                    <include
-                        android:id="@+id/overall_point_line_label_container"
-                        layout="@layout/point_line"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_alignLeft="@id/overall_point_line_label_container"
-                        android:layout_centerVertical="true" />
-
-                    <LinearLayout
+                <LinearLayout
                         android:id="@+id/overall_label_container"
-                        android:layout_width="wrap_content"
+                        android:layout_width="80dp"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="10dp"
-                        android:layout_toEndOf="@id/overall_point_line_label_container"
-                        android:layout_toRightOf="@id/overall_point_line_label_container"
+                        android:layout_marginLeft="50dp"
                         android:gravity="center"
                         android:orientation="vertical">
 
@@ -64,7 +51,8 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:text="80%"
-                            android:textColor="@color/black"
+                            android:gravity="center"
+                            android:textColor="@color/white"
                             android:textSize="28sp"
                             app:font_name="@string/font_name_medium" />
 
@@ -73,31 +61,18 @@
                             android:layout_height="wrap_content"
                             android:text="@string/score_info_overall"
                             android:textSize="12sp"
+                            android:layout_marginLeft="10dp"
                             app:font_name="@string/font_name_medium" />
                     </LinearLayout>
 
 
-                </RelativeLayout>
-
-                <RelativeLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-
-                    <include
-                        android:id="@+id/mandatory_point_line_label_container"
-                        layout="@layout/point_line"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_alignLeft="@id/mandatory_point_line_label_container"
-                        android:layout_centerVertical="true" />
 
                     <LinearLayout
                         android:id="@+id/mandatory_label_container"
-                        android:layout_width="wrap_content"
+                        android:layout_width="80dp"
                         android:layout_height="wrap_content"
-                        android:layout_toEndOf="@id/mandatory_point_line_label_container"
-                        android:layout_toRightOf="@id/mandatory_point_line_label_container"
+                        android:layout_marginLeft="50dp"
+                        android:layout_marginTop="10dp"
                         android:gravity="center"
                         android:orientation="vertical">
 
@@ -105,21 +80,21 @@
                             android:id="@+id/mandatory_percent"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:gravity="center"
                             android:text="100%"
-                            android:textColor="@color/black"
+                            android:textColor="@color/white"
                             android:textSize="28sp"
                             app:font_name="@string/font_name_medium" />
 
                         <org.eyeseetea.malariacare.views.CustomTextView
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:layout_marginLeft="10dp"
                             android:text="@string/mandatory"
                             android:textSize="12sp"
                             app:font_name="@string/font_name_medium" />
                     </LinearLayout>
 
-
-                </RelativeLayout>
             </LinearLayout>
         </RelativeLayout>
 

--- a/app/src/main/java/org/eyeseetea/malariacare/views/SurveyDialog.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/SurveyDialog.java
@@ -91,9 +91,13 @@ public final class SurveyDialog extends AlertDialog {
                         if (surveyAnsweredRatio != null) {
                             overall.setText(surveyAnsweredRatio.getTotalStatus() +
                                     context.getString(R.string.percent));
+                            overall.setBackgroundColor(chart.getOverAllColorByPercentage(
+                                    surveyAnsweredRatio.getTotalStatus(), context));
 
                             mandatory.setText(surveyAnsweredRatio.getMandatoryStatus() +
                                     context.getString(R.string.percent));
+                            mandatory.setBackgroundColor(chart.getMandatoryColorByPercentage(
+                                    surveyAnsweredRatio.getMandatoryStatus(), context));
 
                             chart.createDoublePie(surveyAnsweredRatio.getMandatoryStatus(),
                                     surveyAnsweredRatio.getTotalStatus());


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2092    
* **Related pull-requests:** 

### :tophat: What is the goal?
Changing style in scores of pie chart in the modal menu.

### :memo: How is it being implemented?
Removing the lines and change the background color of the scores, putting the same as the piechart.

### :boom: How can it be tested?

- [x] **Use case 1:** Enter in a feedback video and go back from it.
    - [ ] make login in http://clone.psi-mis.or with KEdemo1.
    - [ ] got to new survey and create a new one, and close it no completing it.
    - [ ] click the 3 dots of the survey and see the  pop up.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

![device-2018-08-09-190529](https://user-images.githubusercontent.com/24573727/43914378-0a98586c-9c08-11e8-9098-22e28c06527d.png)
