### PR TITLE
Fix progress bar and to add message in feedback fragment

### DIFF
--- a/app/src/hnqis/res/layout/feedback.xml
+++ b/app/src/hnqis/res/layout/feedback.xml
@@ -23,14 +23,6 @@
     android:layout_height="match_parent"
     android:gravity="top">
 
-    <ProgressBar
-        android:id="@+id/survey_progress"
-        style="?android:attr/progressBarStyleLarge"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:indeterminate="true" />
-
     <LinearLayout
         android:id="@+id/layoutHeader"
         android:layout_width="match_parent"
@@ -151,4 +143,7 @@
         android:layout_height="match_parent"
         android:background="@color/white"
         android:layout_below="@id/layoutSecondHeader" />
+
+    <include layout="@layout/feedback_progress_view"/>
+
 </RelativeLayout>

--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -289,4 +289,5 @@ clínica"</string>
 <string name="scheduled">Programado</string>
 <string name="reschedule_title_multiple_survey">"%1$d número de encuestas que se reprogramarán para la OU %2$s"</string>
 <string name="survey_not_assigned_facility">"Esta encuesta no está asignada a esta instalación. Por favor, selecciona otra encuesta."</string>
+<string name="feedback_progress_bar_text">Cargando puntuaciones de encuestas ... por favor espere</string>
 </resources>

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -281,4 +281,5 @@ Mensuelle"</string>
 <string name="scheduled">Prévu</string>
 <string name="reschedule_title_multiple_survey">"%1$d nombre d'enquêtes en cours de re-planification pour OU %2$s"</string>
 <string name="survey_not_assigned_facility">"Cette enquête n'est pas affectée à cette installation. Veuillez sélectionner une autre enquête."</string>
+<string name="feedback_progress_bar_text">"Chargement des résultats de l'enquête ... veuillez patienter"</string>
 </resources>

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -301,4 +301,5 @@
 <string name="scheduled">កំណត់ពេល</string>
 <string name="reschedule_title_multiple_survey">"ការស្ទង់មតិចំនួន %1$d ដែលត្រូវបានកំណត់ឡើងវិញសម្រាប់ OU %2$s"</string>
 <string name="survey_not_assigned_facility">"ការស្ទង់មតិនេះមិនត្រូវបានកំណត់ទៅកន្លែងនេះទេ។ សូមជ្រើសរើសការស្ទង់មតិផ្សេងទៀត។"</string>
+<string name="feedback_progress_bar_text">កំពុងដំណើរការពិន្ទុស្ទង់មតិ ... សូមរង់ចាំ</string>
 </resources>

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -296,4 +296,5 @@
 <string name="scheduled">ກໍານົດເວລາ</string>
 <string name="reschedule_title_multiple_survey">"ຈໍານວນການສໍາຫຼວດຈໍານວນ %1$d ຖືກກໍານົດໄວ້ສໍາລັບ OU %2$s"</string>
 <string name="survey_not_assigned_facility">"ການສໍາຫຼວດນີ້ບໍ່ໄດ້ມອບຫມາຍໃຫ້ສະຖານທີ່ນີ້. ກະລຸນາເລືອກການສໍາຫຼວດອື່ນ."</string>
+<string name="feedback_progress_bar_text">ກໍາລັງໂຫລດຄະແນນສໍາຫຼວດ ... ກະລຸນາລໍຖ້າ</string>
 </resources>

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -283,4 +283,5 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="scheduled">Agendado</string>
 <string name="reschedule_title_multiple_survey">"%1$d número de pesquisas sendo reprogramadas para OU %2$s"</string>
 <string name="survey_not_assigned_facility">"Esta pesquisa não está atribuída a essa facilidade. Por favor, selecione outra pesquisa."</string>
+<string name="feedback_progress_bar_text">Carregando pontuações de pesquisa ... por favor aguarde</string>
 </resources>

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -292,4 +292,5 @@ evaluation"</string>
 <string name="improve_no_surveys">"No survey(s) completed for the selection you have made."</string>
 <string name="scheduled">Scheduled</string>
 <string name="survey_not_assigned_facility">"This survey is not assigned to this facility. Please, select another survey."</string>
+<string name="feedback_progress_bar_text">Loading Survey scores... Please wait</string>
 </resources>

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/FeedbackFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/FeedbackFragment.java
@@ -71,7 +71,7 @@ public class FeedbackFragment extends Fragment implements IModuleFragment {
     /**
      * Progress dialog shown while loading
      */
-    private ProgressBar progressBar;
+    private RelativeLayout progressBarContainer;
 
     /**
      * Checkbox that toggle between all|failed questions
@@ -166,7 +166,7 @@ public class FeedbackFragment extends Fragment implements IModuleFragment {
      */
     private void prepareUI(String module) {
         //Get progress
-        progressBar = (ProgressBar) llLayout.findViewById(R.id.survey_progress);
+        progressBarContainer = (RelativeLayout) llLayout.findViewById(R.id.survey_progress_container);
 
         //Set adapter and list
         feedbackAdapter = new FeedbackAdapter(getActivity(),
@@ -243,7 +243,7 @@ public class FeedbackFragment extends Fragment implements IModuleFragment {
      * Stops progress view and shows real data
      */
     private void stopProgress() {
-        this.progressBar.setVisibility(View.GONE);
+        this.progressBarContainer.setVisibility(View.GONE);
         this.feedbackListView.setVisibility(View.VISIBLE);
     }
 
@@ -252,8 +252,7 @@ public class FeedbackFragment extends Fragment implements IModuleFragment {
      */
     private void startProgress() {
         this.feedbackListView.setVisibility(View.GONE);
-        this.progressBar.setVisibility(View.VISIBLE);
-        this.progressBar.setEnabled(true);
+        this.progressBarContainer.setVisibility(View.VISIBLE);
     }
 
     /**

--- a/app/src/main/res/layout/feedback.xml
+++ b/app/src/main/res/layout/feedback.xml
@@ -20,16 +20,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:gravity="top">
-
-    <ProgressBar
-        android:id="@+id/survey_progress"
-        style="?android:attr/progressBarStyleLarge"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:indeterminate="true" />
+    android:layout_height="match_parent">
 
     <LinearLayout
         android:id="@+id/layoutHeader"
@@ -150,4 +141,6 @@
         android:layout_height="match_parent"
         android:background="@color/white"
         android:layout_below="@id/layoutSecondHeader" />
+
+    <include layout="@layout/feedback_progress_view"/>
 </RelativeLayout>

--- a/app/src/main/res/layout/feedback_progress_view.xml
+++ b/app/src/main/res/layout/feedback_progress_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/survey_progress_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:showIn="@layout/feedback">
+
+    <ProgressBar
+        android:id="@+id/survey_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:indeterminate="true"
+        android:visibility="visible"
+        android:indeterminateTint="?attr/colorPrimary" />
+
+    <org.eyeseetea.malariacare.views.CustomTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/survey_progress"
+        android:layout_centerHorizontal="true"
+        android:text="@string/feedback_progress_bar_text" />
+</RelativeLayout>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -231,4 +231,5 @@
 <string name="start"></string>
 <string name="plan_action_provider_title" ></string>
 <string name="scheduled"></string>
+<string name="feedback_progress_bar_text">Loading Survey scores... Please wait</string>
 </resources>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2110 
* **Related pull-requests:** 

### :tophat: What is the goal?

The goal is to show a progress bar with the message "Loading Survey scores... Please wait" while feedback is loading.

### :memo: How is it being implemented?

I have created a new layout with a container, ProgressBar, and TextView for the message. And this layout is included in feedback.xml layout for variant hnqis and eyeseetea.
I have modified logic in feedback fragment to show and hide the Progressbar container.
I have created a string resource for the message in every language

### :boom: How can it be tested?

- [ ] **Use case 1:** Navigate to a feedback and screen should show a progress bar and message while is loading the feedback data.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

![feedback_progress_bar_with_text](https://user-images.githubusercontent.com/5593590/44397589-28287f00-a541-11e8-8c6b-e206c6a07676.png)


