### PR TITLE
Feature put uploaded events

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/importer/models/EventExtended.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/importer/models/EventExtended.java
@@ -74,6 +74,11 @@ public class EventExtended implements VisitableFromSDK {
         this.event = event;
     }
 
+    public EventExtended(String eventUId) {
+        event = new EventFlow();
+        event.setUId(eventUId);
+    }
+
     public EventExtended(EventExtended event) {
         this.event = event.getEvent();
     }
@@ -309,10 +314,6 @@ public class EventExtended implements VisitableFromSDK {
 
     public void setCreationDate(Date creationDate) {
         event.setCreated(new DateTime(creationDate));
-    }
-
-    public void setEventUid(String eventUid) {
-        event.setUId(eventUid);
     }
 
     public static List<EventExtended> fromJsonToEvents(JsonNode jsonNode) {

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
@@ -749,7 +749,8 @@ public class SurveyDB extends BaseModel implements VisitableToSDK {
 
     public void saveConflict(String uid) {
         for (ValueDB value : getValues()) {
-            if (value.getQuestion().getUid().equals(uid)) {
+            if (value.getQuestion()!=null
+                    && value.getQuestion().getUid().equals(uid)) {
                 value.setConflict(true);
                 value.save();
             }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/PushDhisSDKDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/PushDhisSDKDataSource.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.client.sdk.android.api.persistence.flow.EventFlow;
 import org.hisp.dhis.client.sdk.android.api.persistence.flow.StateFlow;
 import org.hisp.dhis.client.sdk.android.api.persistence.flow.TrackedEntityDataValueFlow;
 import org.hisp.dhis.client.sdk.models.common.importsummary.ImportSummary;
+import org.hisp.dhis.client.sdk.models.common.state.Action;
 
 import java.util.HashSet;
 import java.util.List;
@@ -66,8 +67,13 @@ public class PushDhisSDKDataSource {
             return;
         }
 
+        org.hisp.dhis.client.sdk.models.common.state.Action action = Action.TO_POST;
+        if(kind.equals(PushController.Kind.PLANS)){
+            action = Action.TO_UPDATE;
+        }
+
         Observable<Map<String, ImportSummary>> eventObserver =
-                D2.events().push(eventUids);
+                D2.events().push(eventUids, action);
 
         eventObserver
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/pushsummary/PushReport.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/pushsummary/PushReport.java
@@ -102,12 +102,14 @@ public class PushReport {
         if (this.getStatus() == null) {
             return true;
         }
-        if (!this.getStatus().equals(PushReport.Status.SUCCESS)) {
+        if (!this.getStatus().equals(PushReport.Status.SUCCESS) &&
+                !this.getStatus().equals(PushReport.Status.OK)) {
             return true;
         }
         if(emptyImportAllowed){
             return false;
         }
-        return this.getPushedValues().getImported() == 0;
+        return (this.getPushedValues().getImported() == 0
+                && this.getPushedValues().getUpdated() == 0);
     }
 }

--- a/app/src/test/java/org/eyeseetea/malariacare/domain/entity/PushReportTest.java
+++ b/app/src/test/java/org/eyeseetea/malariacare/domain/entity/PushReportTest.java
@@ -68,7 +68,7 @@ public class PushReportTest {
         ImportSummary importSummary = getImportSummary(DATAVALUES_IMPORTED_SUMMARY_JSON);
         PushReport pushReport = PushReportMapper.mapFromImportSummaryToPushReport(importSummary,
                 API_MESSAGE_WITH_CONFLICTS_JSON_KEY);
-        assertThat(!pushReport.hasPushErrors(), is(false));
+        assertThat(pushReport.hasPushErrors(), is(false));
     }
 
     private ImportSummary getImportSummary(String json) {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/malariapp/issues/2126
* **Related pull-requests:** https://github.com/EyeSeeTea/dhis2-android-sdk/pull/409

### :tophat: What is the goal?

Push Plan and observation plan(updated events with put method)

### :memo: How is it being implemented?

I extracted the common code from survey visitor to fill the obsandplan survey.
I modified the hasPushError method to recognice has valid the updated surveys.
I used the new dhis push method to push new or updated surveys(obs and plan surveys).
Avoid some value.question.getUId() exceptiosn when the value was a ServerMetadata without question.

### :boom: How can it be tested?

 **Use case 1:**  Push some surveys and Plan action
 **Use case 2:**  Force conflict with survey.
 **Use case 3:**  Force conflict with plan.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-