### PR TITLE
Feature add nextschedulematrix in v1.4

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
@@ -33,6 +33,8 @@ import org.eyeseetea.malariacare.DashboardActivity;
 import org.eyeseetea.malariacare.ProgressActivity;
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.domain.entity.Credentials;
+import org.eyeseetea.malariacare.domain.entity.NextScheduleMonths;
+import org.eyeseetea.malariacare.domain.entity.Server;
 import org.eyeseetea.malariacare.layout.dashboard.builder.AppSettingsBuilder;
 import org.eyeseetea.malariacare.layout.dashboard.config.DashboardListFilter;
 import org.eyeseetea.malariacare.layout.dashboard.config.DashboardOrientation;
@@ -44,6 +46,14 @@ import java.util.Locale;
 import java.util.Map;
 
 public class PreferencesState {
+
+    public static final String DEFAULT_SCHEDULE_MONTHS_VALUE ="https://data.psi-mis.org";
+    public static final HashMap<String, int[]> nextScheduleMonths = new HashMap<>();
+
+    static {
+        nextScheduleMonths.put(DEFAULT_SCHEDULE_MONTHS_VALUE, new int[]{2, 4, 6});
+        nextScheduleMonths.put("https://zw.hnqis.org/", new int[]{1, 1, 6});
+    }
 
     static Context context;
     private static String TAG = ".PreferencesState";
@@ -96,7 +106,7 @@ public class PreferencesState {
      * Flag that determines if the user did accept the announcement
      */
     private boolean userAccept;
-    private String serverUrl;
+    private Server server;
     private Credentials creedentials;
 
     private PreferencesState() {
@@ -470,24 +480,40 @@ public class PreferencesState {
         }
     }
 
-    public String getServerUrl(){
-        if(serverUrl == null || serverUrl.equals("")) {
-            SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
-                    context);
-            serverUrl = sharedPreferences.getString(
-                    PreferencesState.getInstance().getContext().getResources().getString(
-                            R.string.dhis_url), "");
+    public Server getServer(){
+        if(server==null) {
+            server = loadServer();
         }
-        return serverUrl;
+        return server;
 
     }
 
-    public void reloadServerUrl() {
+    private Server loadServer() {
+        String serverUrl=getServerUrl();
+        server = new Server(getServerUrl(), new NextScheduleMonths(getMonthArray(serverUrl)));
+        return server;
+    }
+
+    private int[] getMonthArray(String serverUrl) {
+        if(nextScheduleMonths.containsKey(serverUrl))
+        {
+            return nextScheduleMonths.get(serverUrl);
+        } else {
+            return nextScheduleMonths.get(DEFAULT_SCHEDULE_MONTHS_VALUE);
+        }
+    }
+
+    private String getServerUrl() {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
                 context);
-        serverUrl = sharedPreferences.getString(
+        String serverUrl = sharedPreferences.getString(
                 PreferencesState.getInstance().getContext().getResources().getString(
                         R.string.dhis_url), "");
+        return serverUrl;
+    }
+
+    public void reloadServerUrl() {
+        loadServer();
     }
 
     private String getPhoneLanguage() {

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/planning/SurveyPlanner.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/planning/SurveyPlanner.java
@@ -28,6 +28,7 @@ import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.Session;
 import org.eyeseetea.malariacare.domain.entity.ScoreType;
+import org.eyeseetea.malariacare.domain.entity.Server;
 import org.eyeseetea.malariacare.utils.Constants;
 
 import java.util.Calendar;
@@ -180,19 +181,20 @@ public class SurveyPlanner {
                         + "lowProductivity: %b",
                 eventDate.toString(), survey.getMainScore(), survey.isLowProductivity()));
 
-        //A -> 6 months
+        Server server = PreferencesState.getInstance().getServer();
+
         ScoreType scoreType = new ScoreType(survey.getMainScore());
         if (scoreType.isTypeA()) {
-            return getInXMonths(eventDate, PreferencesState.getInstance().getServer().getNextScheduleMatrix().getScoreAMonths());
+            return getInXMonths(eventDate, server.getNextScheduleMatrix().getScoreAMonths());
         }
 
         //BC + Low OrgUnit -> 4
         if (survey.isLowProductivity()) {
-            return getInXMonths(eventDate,  PreferencesState.getInstance().getServer().getNextScheduleMatrix().getLowProductivityMonths());
+            return getInXMonths(eventDate,  server.getNextScheduleMatrix().getLowProductivityMonths());
         }
 
         //BC + High OrgUnit -> 2
-        return getInXMonths(eventDate,  PreferencesState.getInstance().getServer().getNextScheduleMatrix().getHighProductivityMonths());
+        return getInXMonths(eventDate,  server.getNextScheduleMatrix().getHighProductivityMonths());
     }
 
     /**

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/planning/SurveyPlanner.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/planning/SurveyPlanner.java
@@ -25,6 +25,7 @@ import org.eyeseetea.malariacare.data.database.model.OrgUnitDB;
 import org.eyeseetea.malariacare.data.database.model.OrgUnitProgramRelationDB;
 import org.eyeseetea.malariacare.data.database.model.ProgramDB;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
+import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.Session;
 import org.eyeseetea.malariacare.domain.entity.ScoreType;
 import org.eyeseetea.malariacare.utils.Constants;
@@ -39,9 +40,6 @@ import java.util.List;
  */
 public class SurveyPlanner {
 
-    private final static int TYPE_A_NEXT_DATE = 6;
-    private final static int TYPE_BC_LOW_NEXT_DATE = 4;
-    private final static int TYPE_BC_HIGH_NEXT_DATE = 2;
     private static final String TAG = ".SurveyPlanner";
 
     private static SurveyPlanner instance;
@@ -185,16 +183,16 @@ public class SurveyPlanner {
         //A -> 6 months
         ScoreType scoreType = new ScoreType(survey.getMainScore());
         if (scoreType.isTypeA()) {
-            return getInXMonths(eventDate, TYPE_A_NEXT_DATE);
+            return getInXMonths(eventDate, PreferencesState.getInstance().getServer().getNextScheduleMatrix().getScoreAMonths());
         }
 
         //BC + Low OrgUnit -> 4
         if (survey.isLowProductivity()) {
-            return getInXMonths(eventDate, TYPE_BC_LOW_NEXT_DATE);
+            return getInXMonths(eventDate,  PreferencesState.getInstance().getServer().getNextScheduleMatrix().getLowProductivityMonths());
         }
 
         //BC + High OrgUnit -> 2
-        return getInXMonths(eventDate, TYPE_BC_HIGH_NEXT_DATE);
+        return getInXMonths(eventDate,  PreferencesState.getInstance().getServer().getNextScheduleMatrix().getHighProductivityMonths());
     }
 
     /**

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/PullDhisApiDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/PullDhisApiDataSource.java
@@ -179,7 +179,7 @@ public class PullDhisApiDataSource {
      * @param url
      */
     public static Response executeCall(JSONObject data, String url, String method) throws IOException {
-        final String DHIS_URL=PreferencesState.getInstance().getServerUrl() + url.replace(" ", "%20");
+        final String DHIS_URL=PreferencesState.getInstance().getServer().getUrl() + url.replace(" ", "%20");
 
         Log.d(TAG, "executeCall Url" + DHIS_URL + "");
 

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/NextScheduleMonths.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/NextScheduleMonths.java
@@ -1,0 +1,32 @@
+package org.eyeseetea.malariacare.domain.entity;
+
+import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+
+public class NextScheduleMonths {
+
+    private int [] month;
+
+    public NextScheduleMonths(int [] month){
+        validate(month);
+        this.month = required(month, "month is required");
+    }
+
+    private void validate(int[] month) {
+        if(month == null || month.length!=3){
+            throw new IllegalArgumentException("array with three dimensions required");
+        }
+    }
+
+    public int getScoreAMonths(){
+        return month[2];
+    }
+
+    public int getLowProductivityMonths(){
+        return month[1];
+    }
+
+    public int getHighProductivityMonths(){
+        return month[0];
+    }
+
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Server.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Server.java
@@ -1,0 +1,22 @@
+package org.eyeseetea.malariacare.domain.entity;
+
+import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+
+public class Server {
+
+    String url;
+    NextScheduleMonths nextScheduleMatrix;
+
+    public Server(String url, NextScheduleMonths nextScheduleMatrix){
+        this.url = required(url,"url is required");
+        this.nextScheduleMatrix = required(nextScheduleMatrix,"nextScheduleMatrix is required");
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public NextScheduleMonths getNextScheduleMatrix() {
+        return nextScheduleMatrix;
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/FeedbackAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/FeedbackAdapter.java
@@ -290,7 +290,7 @@ public class FeedbackAdapter extends BaseAdapter {
         if(PreferencesState.getInstance().isDevelopOptionActive()){
             textView=(TextView)rowLayout.findViewById(R.id.feedback_uid);
             textView.setVisibility(View.VISIBLE);
-            textView.setText(Html.fromHtml("<a href=\""+PreferencesState.getInstance().getServerUrl()+PreferencesState.getInstance().getContext().getString(R.string.api_data_elements)+feedback.getQuestion().getUid()+"\">("+feedback.getQuestion().getUid()+")</a>"));
+            textView.setText(Html.fromHtml("<a href=\""+PreferencesState.getInstance().getServer().getUrl()+PreferencesState.getInstance().getContext().getString(R.string.api_data_elements)+feedback.getQuestion().getUid()+"\">("+feedback.getQuestion().getUid()+")</a>"));
             textView.setMovementMethod(LinkMovementMethod.getInstance());
         }
         //Option label

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/utils/AutoTabLayoutUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/utils/AutoTabLayoutUtils.java
@@ -240,7 +240,7 @@ public class AutoTabLayoutUtils {
         String questionFormHtml = question.getForm_name();
         String questionUId = "";
         if(PreferencesState.getInstance().isDevelopOptionActive()) {
-            questionUId = " <a href=\"" + PreferencesState.getInstance().getServerUrl()
+            questionUId = " <a href=\"" + PreferencesState.getInstance().getServer().getUrl()
                     + PreferencesState.getInstance().getContext().getString(
                     R.string.api_data_elements) + question.getUid() + "\">(" + question.getUid()
                     + ")</a>";

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/utils/LayoutUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/utils/LayoutUtils.java
@@ -175,7 +175,7 @@ public class LayoutUtils {
         actionBar.setDisplayHomeAsUpEnabled(false);
         if(PreferencesState.getInstance().isDevelopOptionActive()) {
             actionBar.setCustomView(R.layout.dev_custom_action_bar);
-            String server = PreferencesState.getInstance().getServerUrl();
+            String server = PreferencesState.getInstance().getServer().getUrl();
             ((CustomTextView) actionBar.getCustomView().findViewById(R.id.action_bar_multititle_dev_subtitle)).setText(server);
         }else {
             actionBar.setCustomView(R.layout.custom_action_bar);
@@ -191,13 +191,13 @@ public class LayoutUtils {
         actionBar.setDisplayHomeAsUpEnabled(false);
         if(PreferencesState.getInstance().isDevelopOptionActive()) {
             actionBar.setCustomView(R.layout.dev_custom_action_bar);
-            String server = PreferencesState.getInstance().getServerUrl();
+            String server = PreferencesState.getInstance().getServer().getUrl();
             ((CustomTextView) actionBar.getCustomView().findViewById(R.id.action_bar_multititle_dev_subtitle)).setText(server);
         }else {
             actionBar.setCustomView(R.layout.custom_action_bar_with_chart);
         }
         updateSurveyActionBarChart(actionBar, surveyAnsweredRatio);
-        String server = PreferencesState.getInstance().getServerUrl();
+        String server = PreferencesState.getInstance().getServer().getUrl();
         ((CustomTextView) activity.findViewById(R.id.action_bar_multititle_title)).setText(title);
         ((CustomTextView) activity.findViewById(R.id.action_bar_multititle_subtitle)).setText(subtitle);
     }

--- a/app/src/test/java/org/eyeseetea/malariacare/domain/entity/ServerShould.java
+++ b/app/src/test/java/org/eyeseetea/malariacare/domain/entity/ServerShould.java
@@ -1,0 +1,65 @@
+package org.eyeseetea.malariacare.domain.entity;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ServerShould {
+
+    public static final String DEFAULT_SCHEDULE_MONTHS_VALUE ="https://data.psi-mis.org";
+    public static final HashMap<String, int[]> nextScheduleMonths = new HashMap<>();
+
+    static {
+        nextScheduleMonths.put(DEFAULT_SCHEDULE_MONTHS_VALUE, new int[]{2, 4, 6});
+        nextScheduleMonths.put("https://zw.hnqis.org/", new int[]{1, 1, 6});
+    }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void return_values_when_is_created_with_correct_values() {
+        Server server = new Server(DEFAULT_SCHEDULE_MONTHS_VALUE, new NextScheduleMonths(nextScheduleMonths.get(DEFAULT_SCHEDULE_MONTHS_VALUE)));
+
+        assertThat(server.getUrl(), is(DEFAULT_SCHEDULE_MONTHS_VALUE));
+        assertThat(server.getNextScheduleMatrix().getScoreAMonths(), is(6));
+        assertThat(server.getNextScheduleMatrix().getHighProductivityMonths(), is(2));
+        assertThat(server.getNextScheduleMatrix().getLowProductivityMonths(), is(4));
+    }
+
+    @Test
+    public void return_correct_values_when_is_created_with_zimbabwe_values() {
+        Server server = new Server(DEFAULT_SCHEDULE_MONTHS_VALUE, new NextScheduleMonths(nextScheduleMonths.get("https://zw.hnqis.org/")));
+
+        assertThat(server.getUrl(), is(DEFAULT_SCHEDULE_MONTHS_VALUE));
+        assertThat(server.getNextScheduleMatrix().getScoreAMonths(), is(6));
+        assertThat(server.getNextScheduleMatrix().getLowProductivityMonths(), is(1));
+        assertThat(server.getNextScheduleMatrix().getHighProductivityMonths(), is(1));
+    }
+
+    @Test
+    public void throw_exception_when_url_is_null() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("url is required");
+        new Server(null, new NextScheduleMonths(nextScheduleMonths.get("https://zw.hnqis.org/")));
+    }
+
+    @Test
+    public void throw_exception_when_next_schedule_months_is_null() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("nextScheduleMatrix is required");
+        new Server(DEFAULT_SCHEDULE_MONTHS_VALUE, null);
+    }
+
+    @Test
+    public void throw_exception_when_next_schedule_months_has_invalid_matrix() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("array with three dimensions required");
+        new Server(DEFAULT_SCHEDULE_MONTHS_VALUE, new NextScheduleMonths(new int[]{1, 1}));
+    }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2134  


### :tophat: What is the goal?

Introduce nextScheduleMatrix in v1.4

 Instead of using hardcoded variables create an object returning the values. The object would obtain that value from a hardcoded matrix (List of Lists). When we ask for a value, we provide the server we are connected to. If the server doesn't exist, the default matrix is used (so the current values). Otherwise, then the appropriate value is provided.

The matrix would look like this:
Any server : +2, +4 +6
https://zw.hnqis.org/ : +1, +1, +6

### :memo: How is it being implemented?

I created a server entity and replaced all the getServerUrl calls to getServer().getUrl() in preferenceState.
The hardcoded matrix is in PreferenceState and when the NextScheduleMonths is created pass the correct array.
I created test to test it too.


### :boom: How can it be tested?
Note: change the sdk to 2.30
- [ ] **Use Case 1:**  complete a survey and the survey in planning should be the correct months

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
