### PR TITLE
Feature add dropdown in 1.4

### DIFF
--- a/app/src/eyeseetea/res/values-es/strings.xml
+++ b/app/src/eyeseetea/res/values-es/strings.xml
@@ -273,4 +273,6 @@ clínica"</string>
 <string name="improve_no_surveys">"No se completaron encuestas para la selección que ha realizado."</string>
 <string name="scheduled">Programado</string>
 <string name="reschedule_title_multiple_survey">"%1$d número de encuestas que se reprogramarán para la OU %2$s"</string>
+
+<string name="other">Otro</string>
 </resources>

--- a/app/src/eyeseetea/res/values-fr/strings.xml
+++ b/app/src/eyeseetea/res/values-fr/strings.xml
@@ -268,4 +268,5 @@ Mensuelle"</string>
 <string name="improve_no_surveys">"Aucune enquête réalisée pour la sélection que vous avez faite."</string>
 <string name="scheduled">Prévu</string>
 <string name="reschedule_title_multiple_survey">"%1$d nombre d'enquêtes en cours de re-planification pour OU %2$s"</string>
+<string name="other">autre</string>
 </resources>

--- a/app/src/eyeseetea/res/values-km/strings.xml
+++ b/app/src/eyeseetea/res/values-km/strings.xml
@@ -282,4 +282,5 @@ evaluation"</string>
 <string name="improve_no_surveys">"គ្មានការស្ទង់មតិសម្រាប់ការជ្រើសរើសដែលអ្នកបានធ្វើទេ។"</string>
 <string name="scheduled">កំណត់ពេល</string>
 <string name="reschedule_title_multiple_survey">"ការស្ទង់មតិចំនួន %1$d ដែលត្រូវបានកំណត់ឡើងវិញសម្រាប់ OU %2$s"</string>
+<string name="other">ផ្សេងទៀត</string>
 </resources>

--- a/app/src/eyeseetea/res/values-lo/strings.xml
+++ b/app/src/eyeseetea/res/values-lo/strings.xml
@@ -280,4 +280,5 @@
 <string name="improve_no_surveys">"ບໍ່ມີການສໍາຫຼວດສໍາລັບການຄັດເລືອກທີ່ທ່ານໄດ້ເຮັດ."</string>
 <string name="scheduled">ກໍານົດເວລາ</string>
 <string name="reschedule_title_multiple_survey">"ຈໍານວນການສໍາຫຼວດຈໍານວນ %1$d ຖືກກໍານົດໄວ້ສໍາລັບ OU %2$s"</string>
+<string name="other">ອື່ນໆ</string>
 </resources>

--- a/app/src/eyeseetea/res/values-pt/strings.xml
+++ b/app/src/eyeseetea/res/values-pt/strings.xml
@@ -269,4 +269,5 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="improve_no_surveys">"Nenhuma pesquisa concluída (s) para a seleção que você fez."</string>
 <string name="scheduled">Agendado</string>
 <string name="reschedule_title_multiple_survey">"%1$d número de pesquisas sendo reprogramadas para OU %2$s"</string>
+<string name="other">outros</string>
 </resources>

--- a/app/src/eyeseetea/res/values/donottranslate.xml
+++ b/app/src/eyeseetea/res/values/donottranslate.xml
@@ -29,4 +29,7 @@
 
     <!-- pull control codes -->
     <string name="pull_program_code" translatable="false">HNQIS</string>
+
+    <string-array name="server_list">
+    </string-array>
 </resources>

--- a/app/src/eyeseetea/res/values/strings.xml
+++ b/app/src/eyeseetea/res/values/strings.xml
@@ -277,4 +277,6 @@ evaluation"</string>
 <string name="improve_no_surveys">"No survey(s) completed for the selection you have made."</string>
 <string name="scheduled">Scheduled</string>
 <string name="reschedule_title_multiple_survey">"%1$d number of surveys being re-scheduled for OU %2$s"</string>
+
+<string name="other">Other</string>
 </resources>

--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -291,4 +291,6 @@ clínica"</string>
 <string name="survey_not_assigned_facility">"Esta encuesta no está asignada a esta instalación. Por favor, selecciona otra encuesta."</string>
 <string name="feedback_progress_bar_text">Cargando puntuaciones de encuestas ... por favor espere</string>
 <string name="login_error_unsupported_server_version">La versión del servidor no esta soportada</string>
+
+<string name="other">Otro</string>
 </resources>

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -283,4 +283,5 @@ Mensuelle"</string>
 <string name="survey_not_assigned_facility">"Cette enquête n'est pas affectée à cette installation. Veuillez sélectionner une autre enquête."</string>
 <string name="feedback_progress_bar_text">"Chargement des résultats de l'enquête ... veuillez patienter"</string>
 <string name="login_error_unsupported_server_version">"La version du serveur n'est pas prise en charge"</string>
+<string name="other">autre</string>
 </resources>

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -302,5 +302,6 @@
 <string name="reschedule_title_multiple_survey">"ការស្ទង់មតិចំនួន %1$d ដែលត្រូវបានកំណត់ឡើងវិញសម្រាប់ OU %2$s"</string>
 <string name="survey_not_assigned_facility">"ការស្ទង់មតិនេះមិនត្រូវបានកំណត់ទៅកន្លែងនេះទេ។ សូមជ្រើសរើសការស្ទង់មតិផ្សេងទៀត។"</string>
 <string name="feedback_progress_bar_text">កំពុងដំណើរការពិន្ទុស្ទង់មតិ ... សូមរង់ចាំ</string>
+<string name="other">ផ្សេងទៀត</string>
 <string name="login_error_unsupported_server_version">កំណែម៉ាស៊ីនមេមិនត្រូវបានគាំទ្រទេ</string>
 </resources>

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -297,5 +297,6 @@
 <string name="reschedule_title_multiple_survey">"ຈໍານວນການສໍາຫຼວດຈໍານວນ %1$d ຖືກກໍານົດໄວ້ສໍາລັບ OU %2$s"</string>
 <string name="survey_not_assigned_facility">"ການສໍາຫຼວດນີ້ບໍ່ໄດ້ມອບຫມາຍໃຫ້ສະຖານທີ່ນີ້. ກະລຸນາເລືອກການສໍາຫຼວດອື່ນ."</string>
 <string name="feedback_progress_bar_text">ກໍາລັງໂຫລດຄະແນນສໍາຫຼວດ ... ກະລຸນາລໍຖ້າ</string>
+<string name="other">ອື່ນໆ</string>
 <string name="login_error_unsupported_server_version">ເວີຊັນຂອງເຄື່ອງແມ່ຂ່າຍບໍ່ສະຫນັບສະຫນູນ</string>
 </resources>

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -284,5 +284,6 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="reschedule_title_multiple_survey">"%1$d número de pesquisas sendo reprogramadas para OU %2$s"</string>
 <string name="survey_not_assigned_facility">"Esta pesquisa não está atribuída a essa facilidade. Por favor, selecione outra pesquisa."</string>
 <string name="feedback_progress_bar_text">Carregando pontuações de pesquisa ... por favor aguarde</string>
+<string name="other">outros</string>
 <string name="login_error_unsupported_server_version">A versão do servidor não é suportada</string>
 </resources>

--- a/app/src/hnqis/res/values/donottranslate.xml
+++ b/app/src/hnqis/res/values/donottranslate.xml
@@ -24,7 +24,7 @@
     <string name="app_name" translatable="false">HNQIS (dev)</string>
 
     <!-- default server url -->
-    <string name="login_info_dhis_default_server_url" translatable="false">https://data.psi-mis.org</string>
+    <string name="login_info_dhis_default_server_url" translatable="false">https://data.psi-mis.org/</string>
     <string name="assessment_no_schedule_date" translatable="false">"-"</string>
 
     <!-- pull control codes -->

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -294,4 +294,6 @@ evaluation"</string>
 <string name="survey_not_assigned_facility">"This survey is not assigned to this facility. Please, select another survey."</string>
 <string name="feedback_progress_bar_text">Loading Survey scores... Please wait</string>
 <string name="login_error_unsupported_server_version">The server version is not supported</string>
+
+<string name="other">Other</string>
 </resources>

--- a/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
@@ -19,6 +19,7 @@
 
 package org.eyeseetea.malariacare;
 
+import android.animation.LayoutTransition;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
@@ -26,9 +27,12 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.CardView;
 import android.text.Editable;
 import android.text.Html;
@@ -39,8 +43,18 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
 import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
+import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -73,6 +87,9 @@ public class LoginActivity extends AbsLoginActivity {
 
     private CircularProgressBar progressBar;
     private ViewGroup loginViewsContainer;
+    private Spinner serverSpinner;
+    private LinearLayout serverContainer;
+    private EditText serverEditText;
     private static LoginActivity mLoginActivity;
 
     @Override
@@ -98,6 +115,40 @@ public class LoginActivity extends AbsLoginActivity {
 
         loginViewsContainer = (CardView) findViewById(R.id.layout_login_views);
 
+        serverSpinner = (Spinner) findViewById(R.id.server_spinner);
+        serverContainer = (LinearLayout) findViewById(R.id.edittext_server_url_container);
+        serverEditText = (EditText) findViewById(R.id.edittext_server_url);
+
+        initServerAdapter();
+    }
+
+    private void initServerAdapter() {
+        String[] serverList = getResources().getStringArray(R.array.server_list);
+        if(serverList.length<1) {
+            return;
+        }
+        ArrayAdapter serversListAdapter = new ArrayAdapter<>(getBaseContext(),android.R.layout.simple_spinner_item, serverList);
+        serverSpinner.setAdapter(serversListAdapter);
+        serverSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                String value = parent.getItemAtPosition(position).toString();
+                if(value.equals(parent.getContext().getResources().getString(R.string.other))){
+                    serverEditText.setText("");
+                    serverContainer.setVisibility(View.VISIBLE);
+                } else {
+                    if(serverContainer.getVisibility()==View.VISIBLE){
+                        serverContainer.setVisibility(View.GONE);
+                    }
+                    serverEditText.setText(parent.getItemAtPosition(position).toString());
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+                parent.setSelection(0);
+            }
+        });
     }
 
     private void replaceDhisLogoToHNQISLogo() {

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2016, University of Oslo
+  ~
+  ~ All rights reserved.
+  ~ Redistribution and use in source and binary forms, with or without
+  ~ modification, are permitted provided that the following conditions are met:
+  ~ Redistributions of source code must retain the above copyright notice, this
+  ~ list of conditions and the following disclaimer.
+  ~
+  ~ Redistributions in binary form must reproduce the above copyright notice,
+  ~ this list of conditions and the following disclaimer in the documentation
+  ~ and/or other materials provided with the distribution.
+  ~ Neither the name of the HISP project nor the names of its contributors may
+  ~ be used to endorse or promote products derived from this software without
+  ~ specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ~ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  ~ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  ~ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+  ~ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  ~ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  ~ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  ~ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/color_primary_default"
+            android:fillViewport="true"
+            android:orientation="vertical">
+
+    <RelativeLayout
+        android:id="@+id/layout_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:gravity="center"
+        android:padding="8dp">
+
+        <FrameLayout
+            android:id="@+id/layout_dhis_logo"
+            android:layout_width="110dp"
+            android:layout_height="110dp"
+            android:layout_centerHorizontal="true">
+
+            <org.hisp.dhis.client.sdk.ui.views.CircleView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:circle_radius="50dp"
+                app:stroke_color="@android:color/white"
+                app:stroke_width="@dimen/circle_stroke_width"/>
+
+            <fr.castorflex.android.circularprogressbar.CircularProgressBar
+                android:id="@+id/progress_bar_circular"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:indeterminate="true"/>
+
+            <org.hisp.dhis.client.sdk.ui.views.FontTextView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:text="@string/two"
+                android:textColor="@android:color/white"
+                android:textSize="74sp"
+                app:font="@string/font_name_regular"/>
+
+        </FrameLayout>
+
+        <android.support.v7.widget.CardView
+            android:id="@+id/layout_login_views"
+            android:layout_width="384dp"
+            android:layout_height="384dp"
+            android:layout_below="@id/layout_dhis_logo"
+            android:layout_centerHorizontal="true"
+            app:cardBackgroundColor="@android:color/white"
+            app:cardCornerRadius="4dp"
+            app:cardElevation="4dp"
+            app:cardUseCompatPadding="true">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center_vertical"
+                android:orientation="vertical"
+                android:padding="16dp"
+                android:weightSum="1">
+
+                <org.eyeseetea.malariacare.views.CustomSpinner
+                    android:id="@+id/server_spinner"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:layout_marginBottom="8dp"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"/>
+
+                <android.support.design.widget.TextInputLayout
+                    android:id="@+id/edittext_server_url_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:visibility="gone"
+                    android:layout_marginBottom="8dp">
+
+
+                    <org.hisp.dhis.client.sdk.ui.views.FontTextInputEditText
+                        android:id="@+id/edittext_server_url"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center_vertical"
+                        android:hint="@string/server_url"
+                        android:inputType="textUri"
+                        android:singleLine="true"
+                        app:font="@string/font_name_regular"/>
+                </android.support.design.widget.TextInputLayout>
+
+                <android.support.design.widget.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:layout_marginBottom="8dp">
+
+                    <org.hisp.dhis.client.sdk.ui.views.FontTextInputEditText
+                        android:id="@+id/edittext_username"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center_vertical"
+                        android:hint="@string/username"
+                        android:inputType="text"
+                        android:singleLine="true"
+                        app:font="@string/font_name_regular"/>
+                </android.support.design.widget.TextInputLayout>
+
+                <android.support.design.widget.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:layout_marginBottom="16dp">
+
+                    <org.hisp.dhis.client.sdk.ui.views.FontTextInputEditText
+                        android:id="@+id/edittext_password"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center_vertical"
+                        android:hint="@string/password"
+                        android:inputType="textPassword"
+                        android:singleLine="true"
+                        app:font="@string/font_name_regular"/>
+                </android.support.design.widget.TextInputLayout>
+
+                <org.hisp.dhis.client.sdk.ui.views.FontButton
+                    android:id="@+id/button_log_in"
+                    android:layout_width="196dp"
+                    android:layout_height="40dp"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginBottom="8dp"
+                    android:background="@drawable/button_selector_accent"
+                    android:text="@string/log_in"
+                    android:textAllCaps="true"
+                    android:textColor="@android:color/white"
+                    android:textSize="17sp"
+                    app:font="@string/font_name_medium"/>
+
+                <org.hisp.dhis.client.sdk.ui.views.FontButton
+                    android:id="@+id/button_log_out"
+                    android:layout_width="196dp"
+                    android:layout_height="40dp"
+                    android:layout_gravity="center_horizontal"
+                    android:background="@drawable/button_selector_red"
+                    android:text="@string/clear_and_logout"
+                    android:textAllCaps="true"
+                    android:textColor="@android:color/white"
+                    android:textSize="17sp"
+                    app:font="@string/font_name_medium"/>
+
+            </LinearLayout>
+
+        </android.support.v7.widget.CardView>
+
+    </RelativeLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -92,21 +92,27 @@
                 android:orientation="vertical"
                 android:padding="16dp"
                 android:weightSum="1">
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="50dp"
+                    android:gravity="center_vertical"
+                    android:paddingTop="8dp"
+                    android:layout_marginBottom="8dp">
 
                 <org.eyeseetea.malariacare.views.CustomSpinner
                     android:id="@+id/server_spinner"
                     android:layout_width="match_parent"
-                    android:layout_height="56dp"
-                    android:layout_marginBottom="8dp"
+                    android:layout_height="match_parent"
                     android:gravity="center_vertical"
                     android:spinnerMode="dropdown"/>
+
+                </LinearLayout>
 
                 <android.support.design.widget.TextInputLayout
                     android:id="@+id/edittext_server_url_container"
                     android:layout_width="match_parent"
-                    android:layout_height="56dp"
-                    android:visibility="gone"
-                    android:layout_marginBottom="8dp">
+                    android:layout_height="50dp"
+                    android:visibility="gone" >
 
 
                     <org.hisp.dhis.client.sdk.ui.views.FontTextInputEditText
@@ -122,7 +128,7 @@
 
                 <android.support.design.widget.TextInputLayout
                     android:layout_width="match_parent"
-                    android:layout_height="56dp"
+                    android:layout_height="50dp"
                     android:layout_marginBottom="8dp">
 
                     <org.hisp.dhis.client.sdk.ui.views.FontTextInputEditText
@@ -134,11 +140,12 @@
                         android:inputType="text"
                         android:singleLine="true"
                         app:font="@string/font_name_regular"/>
+
                 </android.support.design.widget.TextInputLayout>
 
                 <android.support.design.widget.TextInputLayout
                     android:layout_width="match_parent"
-                    android:layout_height="56dp"
+                    android:layout_height="50dp"
                     android:layout_marginBottom="16dp">
 
                     <org.hisp.dhis.client.sdk.ui.views.FontTextInputEditText

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -139,4 +139,11 @@
         <item>km</item>
         <item>lo</item>
     </string-array>
+    <string-array name="server_list">
+        <item>@string/login_info_dhis_default_server_url</item>
+        <item>https://sfhnigeria.psi-mis.org/</item>
+        <item>https://singapore-dev.psi-mis.org/</item>
+        <item>https://zw.hnqis.org/</item>
+        <item>@string/other</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2136  


### :tophat: What is the goal?

Server would change into a dropdown menu with the following options:

data.psi-mis.org <-- Default selected
sfhnigeria.psi-mis.org
singapore-dev.psi-mis.org
zw.hnqis.org
Other
When other is selected a textfield appears to write the server address.

### :memo: How is it being implemented?

I added a copy of the dhis login layout and i added the spinner and some IDs.
When a item is selected in the spinner the serverEditText sets his value.
When the user select the "other" option the serverEditText will be shown.

### :boom: How can it be tested?

Note: change the sdk to 2.30!!!

- [ ] **Use Case 1:**  Install app and select a server. The app should login in the selected server.
- [ ] **Use Case 1:**  Install app and select other option. The app should display the edittext, and use its value to use in login.


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

![newspinner](https://user-images.githubusercontent.com/5302538/46274876-34015b00-c55b-11e8-9d92-7be60fc89ca6.png)

![newspinner2](https://user-images.githubusercontent.com/5302538/46274896-3c599600-c55b-11e8-86e5-b51d44b9404c.png)

