### PR TITLE
hide composite score child by default

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/feedback/CompositeScoreFeedback.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/feedback/CompositeScoreFeedback.java
@@ -34,10 +34,6 @@ public class CompositeScoreFeedback implements Feedback {
     private List<CompositeScoreFeedback> mCompositeScoreFeedbackList;
     private boolean isShown;
     private boolean isRoot;
-    /**
-     * Default value to decide if the composite score is shown or hidden.
-     */
-    private boolean defaultVisibility=true;
 
     public boolean isShown() {
         return this.isShown;
@@ -52,7 +48,7 @@ public class CompositeScoreFeedback implements Feedback {
         this.score=score;
         mCompositeScoreFeedbackList = new ArrayList<>();
         mFeedbackList = new ArrayList<>();
-        this.isShown = defaultVisibility;
+        this.isShown = isRoot;
         this.isRoot = isRoot;
     }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2149 
* **Related pull-requests:**

### :tophat: What is the goal?

Hide the composite score children by default:
issue description:
"Is it possible to collapse the improve module at tab level (image 1) so that when you open, this is the default display? Right now, the default is all tabs and all sections are open (Image 2)

[Image 1](https://user-images.githubusercontent.com/26415203/46399798-76fd3300-c701-11e8-95cc-a88c53cbffff.jpg)

[Image 2](https://user-images.githubusercontent.com/26415203/46399811-7ebcd780-c701-11e8-892d-aa8332ab69cd.jpg)
"
### :memo: How is it being implemented?

sets as hidden the child composite scores

### :boom: How can it be tested?

 **Use case 1:** Open a survey feedback and see the compositescore roots collapsed.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
