### PR TITLE
add new message on feedback share if the survey is not sent

### DIFF
--- a/app/src/eyeseetea/res/values-es/strings.xml
+++ b/app/src/eyeseetea/res/values-es/strings.xml
@@ -275,4 +275,5 @@ clínica"</string>
 <string name="reschedule_title_multiple_survey">"%1$d número de encuestas que se reprogramarán para la OU %2$s"</string>
 
 <string name="other">Otro</string>
+<string name="feedback_not_sent">"La URL de feedback no está disponible porque la encuesta aún no se ha enviado al servidor. Intenta compartir los comentarios de nuevo más tarde"</string>
 </resources>

--- a/app/src/eyeseetea/res/values-fr/strings.xml
+++ b/app/src/eyeseetea/res/values-fr/strings.xml
@@ -269,4 +269,5 @@ Mensuelle"</string>
 <string name="scheduled">Prévu</string>
 <string name="reschedule_title_multiple_survey">"%1$d nombre d'enquêtes en cours de re-planification pour OU %2$s"</string>
 <string name="other">autre</string>
+<string name="feedback_not_sent">"L'URL de commentaires n'est pas disponible car l'enquête n'a pas encore été envoyée au serveur. Essayez de partager les commentaires plus tard."</string>
 </resources>

--- a/app/src/eyeseetea/res/values-km/strings.xml
+++ b/app/src/eyeseetea/res/values-km/strings.xml
@@ -283,4 +283,5 @@ evaluation"</string>
 <string name="scheduled">កំណត់ពេល</string>
 <string name="reschedule_title_multiple_survey">"ការស្ទង់មតិចំនួន %1$d ដែលត្រូវបានកំណត់ឡើងវិញសម្រាប់ OU %2$s"</string>
 <string name="other">ផ្សេងទៀត</string>
+<string name="feedback_not_sent">"URL ឆ្លើយតបមិនមានទេដោយសារតែការស្ទង់មតិ។ ព្យាយាមចែករំលែកមតិត្រឡប់ម្តងទៀតនៅពេលក្រោយ។"</string>
 </resources>

--- a/app/src/eyeseetea/res/values-lo/strings.xml
+++ b/app/src/eyeseetea/res/values-lo/strings.xml
@@ -281,4 +281,5 @@
 <string name="scheduled">ກໍານົດເວລາ</string>
 <string name="reschedule_title_multiple_survey">"ຈໍານວນການສໍາຫຼວດຈໍານວນ %1$d ຖືກກໍານົດໄວ້ສໍາລັບ OU %2$s"</string>
 <string name="other">ອື່ນໆ</string>
+<string name="feedback_not_sent">"URL ຄວາມຄິດເຫັນບໍ່ສາມາດໃຊ້ໄດ້ເນື່ອງຈາກການສໍາຫຼວດ. ລອງແບ່ງປັນຄວາມຄິດເຫັນຕໍ່ອີກເທື່ອຫນຶ່ງ."</string>
 </resources>

--- a/app/src/eyeseetea/res/values-pt/strings.xml
+++ b/app/src/eyeseetea/res/values-pt/strings.xml
@@ -270,4 +270,5 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="scheduled">Agendado</string>
 <string name="reschedule_title_multiple_survey">"%1$d número de pesquisas sendo reprogramadas para OU %2$s"</string>
 <string name="other">outros</string>
+<string name="feedback_not_sent">"O URL de comentários não está disponível devido à pesquisa. Tente compartilhar o feedback novamente mais tarde."</string>
 </resources>

--- a/app/src/eyeseetea/res/values/strings.xml
+++ b/app/src/eyeseetea/res/values/strings.xml
@@ -279,4 +279,5 @@ evaluation"</string>
 <string name="reschedule_title_multiple_survey">"%1$d number of surveys being re-scheduled for OU %2$s"</string>
 
 <string name="other">Other</string>
+<string name="feedback_not_sent">"The feedback URL is not available because the survey hasn't been sent to the server yet. Try sharing the feedback again later."</string>
 </resources>

--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -293,4 +293,5 @@ clínica"</string>
 <string name="login_error_unsupported_server_version">La versión del servidor no esta soportada</string>
 
 <string name="other">Otro</string>
+<string name="feedback_not_sent">"La URL de feedback no está disponible porque la encuesta aún no se ha enviado al servidor. Intenta compartir los comentarios de nuevo más tarde"</string>
 </resources>

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -284,4 +284,5 @@ Mensuelle"</string>
 <string name="feedback_progress_bar_text">"Chargement des résultats de l'enquête ... veuillez patienter"</string>
 <string name="login_error_unsupported_server_version">"La version du serveur n'est pas prise en charge"</string>
 <string name="other">autre</string>
+<string name="feedback_not_sent">"L'URL de commentaires n'est pas disponible car l'enquête n'a pas encore été envoyée au serveur. Essayez de partager les commentaires plus tard."</string>
 </resources>

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -304,4 +304,5 @@
 <string name="feedback_progress_bar_text">កំពុងដំណើរការពិន្ទុស្ទង់មតិ ... សូមរង់ចាំ</string>
 <string name="other">ផ្សេងទៀត</string>
 <string name="login_error_unsupported_server_version">កំណែម៉ាស៊ីនមេមិនត្រូវបានគាំទ្រទេ</string>
+<string name="feedback_not_sent">"URL ឆ្លើយតបមិនមានទេដោយសារតែការស្ទង់មតិ។ ព្យាយាមចែករំលែកមតិត្រឡប់ម្តងទៀតនៅពេលក្រោយ។"</string>
 </resources>

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -299,4 +299,5 @@
 <string name="feedback_progress_bar_text">ກໍາລັງໂຫລດຄະແນນສໍາຫຼວດ ... ກະລຸນາລໍຖ້າ</string>
 <string name="other">ອື່ນໆ</string>
 <string name="login_error_unsupported_server_version">ເວີຊັນຂອງເຄື່ອງແມ່ຂ່າຍບໍ່ສະຫນັບສະຫນູນ</string>
+<string name="feedback_not_sent">"URL ຄວາມຄິດເຫັນບໍ່ສາມາດໃຊ້ໄດ້ເນື່ອງຈາກການສໍາຫຼວດ. ລອງແບ່ງປັນຄວາມຄິດເຫັນຕໍ່ອີກເທື່ອຫນຶ່ງ."</string>
 </resources>

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -286,4 +286,5 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="feedback_progress_bar_text">Carregando pontuações de pesquisa ... por favor aguarde</string>
 <string name="other">outros</string>
 <string name="login_error_unsupported_server_version">A versão do servidor não é suportada</string>
+<string name="feedback_not_sent">"O URL de comentários não está disponível devido à pesquisa. Tente compartilhar o feedback novamente mais tarde."</string>
 </resources>

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -296,4 +296,5 @@ evaluation"</string>
 <string name="login_error_unsupported_server_version">The server version is not supported</string>
 
 <string name="other">Other</string>
+<string name="feedback_not_sent">"The feedback URL is not available because the survey hasn't been sent to the server yet. Try sharing the feedback again later."</string>
 </resources>

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
@@ -432,8 +432,8 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
     }
 
     @Override
-    public void shareNotSent(String data) {
-        shareData(data);
+    public void shareNotSent(String surveyNoSentMessage) {
+        shareData(surveyNoSentMessage);
     }
 
     @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
@@ -428,13 +428,12 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
         String data = extractTextData(obsActionPlan, survey, criticalQuestions,
                 compositeScoresTree);
 
-        Intent sendIntent = new Intent();
-        sendIntent.setAction(Intent.ACTION_SEND);
-        sendIntent.putExtra(Intent.EXTRA_TEXT, data);
-        sendIntent.setType("text/plain");
-        getActivity().startActivity(sendIntent);
+        shareData(data);
+    }
 
-        System.out.println("data:" + data);
+    @Override
+    public void shareNotSent(String data) {
+        shareData(data);
     }
 
     @Override
@@ -525,5 +524,15 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
         }
         System.out.println("data:" + data);
         return data;
+    }
+
+    private void shareData(String data) {
+        Intent sendIntent = new Intent();
+        sendIntent.setAction(Intent.ACTION_SEND);
+        sendIntent.putExtra(Intent.EXTRA_TEXT, data);
+        sendIntent.setType("text/plain");
+        getActivity().startActivity(sendIntent);
+
+        System.out.println("data:" + data);
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/ObsActionPlanPresenter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/ObsActionPlanPresenter.java
@@ -313,7 +313,7 @@ public class ObsActionPlanPresenter {
         void shareByText(ObsActionPlanDB obsActionPlan,SurveyDB survey, List<QuestionDB> criticalQuestions,
                 List<CompositeScoreDB> compositeScoresTree);
 
-        void shareNotSent(String data);
+        void shareNotSent(String surveyNoSentMessage);
 
         void enableShareButton();
 

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/ObsActionPlanPresenter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/ObsActionPlanPresenter.java
@@ -15,6 +15,7 @@ import org.eyeseetea.malariacare.data.database.model.QuestionDB;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.utils.planning.SurveyPlanner;
 import org.eyeseetea.malariacare.observables.ObservablePush;
+import org.eyeseetea.malariacare.utils.Constants;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -225,9 +226,13 @@ public class ObsActionPlanPresenter {
                 mSurvey.getId_survey());
 
         List<CompositeScoreDB> compositeScoresTree = getValidTreeOfCompositeScores();
-
         if (mView != null) {
-            mView.shareByText(mObsActionPlan, mSurvey, criticalQuestions, compositeScoresTree);
+
+            if(mSurvey.getStatus() != Constants.SURVEY_SENT){
+                mView.shareNotSent(mContext.getString(R.string.feedback_not_sent));
+            }else {
+                mView.shareByText(mObsActionPlan, mSurvey, criticalQuestions, compositeScoresTree);
+            }
         }
     }
 
@@ -307,6 +312,8 @@ public class ObsActionPlanPresenter {
 
         void shareByText(ObsActionPlanDB obsActionPlan,SurveyDB survey, List<QuestionDB> criticalQuestions,
                 List<CompositeScoreDB> compositeScoresTree);
+
+        void shareNotSent(String data);
 
         void enableShareButton();
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2150  
* **Related pull-requests:**

### :tophat: What is the goal?

Change message when URL is not yet ready for sharing the feedback


### :memo: How is it being implemented?

Added presenter method to show the alternative feedback text when the survey is not sent

### :boom: How can it be tested?

 **Use case 1:** Open a sent survey feedback, open plan action click on share and see the shared text
 **Use case 1:** Open a not sent survey feedback, open plan action click on share and see the new text in shared text

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
