### PR TITLE
load question completion graph on start survey

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/SurveyFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/SurveyFragment.java
@@ -209,7 +209,6 @@ public class SurveyFragment extends Fragment implements DomainEventSubscriber<Va
 
     private void initializeSurvey() {
         final SurveyDB survey = Session.getSurveyByModule(moduleName);
-
         surveyAnsweredRatioRepository = new SurveyAnsweredRatioRepository();
         asyncExecutor = new AsyncExecutor();
         mainExecutor = new UIThreadExecutor();
@@ -229,6 +228,7 @@ public class SurveyFragment extends Fragment implements DomainEventSubscriber<Va
                         Log.d(getClass().getName(), "onComplete");
                         mSurveyAnsweredRatio = surveyAnsweredRatio;
                         tabAdapter.notifyDataSetChanged();
+                        updateChart();
                     }
                 });
     }
@@ -406,12 +406,6 @@ public class SurveyFragment extends Fragment implements DomainEventSubscriber<Va
     }
 
     private void runChartUpdate(final ValueChangedEvent valueChangedEvent) {
-
-        final DoublePieChart doublePieChart =
-                ActionBarStrategy.getActionBarPie(DashboardActivity.dashboardActivity);
-        if(doublePieChart!=null){
-            doublePieChart.setVisibility(View.VISIBLE);
-        }
         for (Question question : valueChangedEvent.getQuestions()) {
             if(question.isComputable()) {
                 if (valueChangedEvent.getAction().equals(
@@ -431,6 +425,12 @@ public class SurveyFragment extends Fragment implements DomainEventSubscriber<Va
             }
         }
 
+        reloadChart();
+        }
+
+    private void reloadChart() {
+        IAsyncExecutor asyncExecutor = new AsyncExecutor();
+        IMainExecutor mainExecutor = new UIThreadExecutor();
         SaveSurveyAnsweredRatioUseCase saveSurveyAnsweredRatioUseCase =
                 new SaveSurveyAnsweredRatioUseCase(
                         new SurveyAnsweredRatioRepository(), mainExecutor,
@@ -445,16 +445,22 @@ public class SurveyFragment extends Fragment implements DomainEventSubscriber<Va
                     public void onComplete(
                             SurveyAnsweredRatio surveyAnsweredRatio) {
                         if (surveyAnsweredRatio != null) {
-                            if(doublePieChart!=null) {
-                                LayoutUtils.updateChart(mSurveyAnsweredRatio,
-                                        doublePieChart);
-                            }
+                            updateChart();
                         }
                     }
                 }, mSurveyAnsweredRatio);
-        }
+    }
 
-@Override
+    private void updateChart() {
+        final DoublePieChart doublePieChart =
+                ActionBarStrategy.getActionBarPie(DashboardActivity.dashboardActivity);
+        if(doublePieChart!=null) {
+            LayoutUtils.updateChart(mSurveyAnsweredRatio,
+                    doublePieChart);
+        }
+    }
+
+    @Override
 public Class<ValueChangedEvent> subscribedToEventType(){
         return ValueChangedEvent.class;
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2156


### :tophat: What is the goal?

To create a new survey the complete graph not appears until a question is answered 

### :memo: How is it being implemented?

I extract the reload pie method and call it on survey load.

### :boom: How can it be tested?

 **Use case 1:** Create a survey and check the pie

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [] Yeap, here you have some screenshots-
