### PR TITLE
Feature uncoupled metadata pull org unit level

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/boundaries/IMetadataLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/boundaries/IMetadataLocalDataSource.java
@@ -1,0 +1,10 @@
+package org.eyeseetea.malariacare.data.boundaries;
+
+import org.eyeseetea.malariacare.domain.entity.IMetadata;
+
+import java.util.List;
+
+public interface IMetadataLocalDataSource<T extends IMetadata> {
+    List<T> getAll();
+    void clearAndSave(List<T> metadataList) throws Exception;
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/data/boundaries/IMetadataRemoteDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/boundaries/IMetadataRemoteDataSource.java
@@ -1,0 +1,8 @@
+package org.eyeseetea.malariacare.data.boundaries;
+
+import org.eyeseetea.malariacare.domain.entity.IMetadata;
+import java.util.List;
+
+public interface IMetadataRemoteDataSource <T extends IMetadata>{
+    List<T> getAll() throws Exception;
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/OrgUnitLevelLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/OrgUnitLevelLocalDataSource.java
@@ -1,0 +1,52 @@
+package org.eyeseetea.malariacare.data.database.datasources;
+
+import com.raizlabs.android.dbflow.sql.language.Delete;
+import com.raizlabs.android.dbflow.sql.language.Select;
+
+import org.eyeseetea.malariacare.data.boundaries.IMetadataLocalDataSource;
+import org.eyeseetea.malariacare.data.database.model.OrgUnitLevelDB;
+import org.eyeseetea.malariacare.domain.entity.OrgUnitLevel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OrgUnitLevelLocalDataSource
+        implements IMetadataLocalDataSource<OrgUnitLevel> {
+    @Override
+    public List<OrgUnitLevel> getAll() {
+        List<OrgUnitLevelDB> orgUnitLevelsDB = new Select().from(OrgUnitLevelDB.class).queryList();
+
+        return mapToDomain(orgUnitLevelsDB);
+    }
+
+    @Override
+    public void clearAndSave(List<OrgUnitLevel> orgUnitLevels) throws Exception {
+        Delete.table(OrgUnitLevelDB.class);
+
+        List<OrgUnitLevelDB> orgUnitLevelsDB = mapToDB(orgUnitLevels);
+
+        for (OrgUnitLevelDB orgUnitLevelDB:orgUnitLevelsDB) {
+            orgUnitLevelDB.save();
+        }
+    }
+
+    private List<OrgUnitLevel> mapToDomain(List<OrgUnitLevelDB> orgUnitLevelsDB) {
+        List<OrgUnitLevel> orgUnitLevels = new ArrayList<>();
+
+        for (OrgUnitLevelDB orgUnitLevelDB:orgUnitLevelsDB) {
+            orgUnitLevels.add(new OrgUnitLevel(orgUnitLevelDB.getUid(),orgUnitLevelDB.getName()));
+        }
+
+        return orgUnitLevels;
+    }
+
+    private List<OrgUnitLevelDB> mapToDB(List<OrgUnitLevel> orgUnitLevels) {
+        List<OrgUnitLevelDB> orgUnitLevelsDB = new ArrayList<>();
+
+        for (OrgUnitLevel orgUnitLevel:orgUnitLevels) {
+            orgUnitLevelsDB.add(new OrgUnitLevelDB(orgUnitLevel.getUid(),orgUnitLevel.getName()));
+        }
+
+        return orgUnitLevelsDB;
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/importer/PullMetadataController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/importer/PullMetadataController.java
@@ -23,8 +23,6 @@ import android.util.Log;
 
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.IPullSourceCallback;
-import org.eyeseetea.malariacare.data.boundaries.IMetadataLocalDataSource;
-import org.eyeseetea.malariacare.data.boundaries.IMetadataRemoteDataSource;
 import org.eyeseetea.malariacare.data.database.AppDatabase;
 import org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.models.DataElementExtended;
 import org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.models.OptionSetExtended;
@@ -55,9 +53,6 @@ public class PullMetadataController implements IPullMetadataController {
 
     private final String TAG = ".PullMetadataController";
 
-    private IMetadataLocalDataSource mOrgUnitLevelLocalDataSource;
-    private IMetadataRemoteDataSource mOrgUnitLevelRemoteDataSource;
-
     PullDhisSDKDataSource pullRemoteDataSource;
     IPullMetadataController.Callback callback;
 
@@ -74,7 +69,7 @@ public class PullMetadataController implements IPullMetadataController {
 
     @Override
     public void pullMetadata(final IPullMetadataController.Callback callback) {
-
+        //TODO: this method on the future should be in PullUseCase
         try {
 
             mOrgUnitLevelRepository.getAll(ReadPolicy.NETWORK_FIRST);
@@ -83,6 +78,7 @@ public class PullMetadataController implements IPullMetadataController {
             callback.onError(e);
         }
 
+        //TODO:Remove OldPull when pull is uncoupled from dhis 2 sdk
         oldPull(callback);
     }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/dataSources/ObservationSDKDhisDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/dataSources/ObservationSDKDhisDataSource.java
@@ -17,7 +17,7 @@
  *  along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.eyeseetea.malariacare.data.remote.sdk.data;
+package org.eyeseetea.malariacare.data.remote.sdk.dataSources;
 
 import android.content.Context;
 
@@ -25,6 +25,7 @@ import org.eyeseetea.malariacare.data.boundaries.IDataLocalDataSource;
 import org.eyeseetea.malariacare.data.boundaries.IDataRemoteDataSource;
 import org.eyeseetea.malariacare.data.database.model.UserDB;
 import org.eyeseetea.malariacare.data.database.utils.Session;
+import org.eyeseetea.malariacare.data.remote.sdk.mapper.FromObservationEventMapper;
 import org.eyeseetea.malariacare.data.sync.mappers.PushReportMapper;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IOptionRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IServerMetadataRepository;

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/dataSources/OrgUnitLevelSDKDhisDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/dataSources/OrgUnitLevelSDKDhisDataSource.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017.
+ *
+ * This file is part of QA App.
+ *
+ *  Health Network QIS App is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Health Network QIS App is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eyeseetea.malariacare.data.remote.sdk.dataSources;
+
+import org.eyeseetea.malariacare.data.boundaries.IMetadataRemoteDataSource;
+import org.eyeseetea.malariacare.data.database.model.CompositeScoreDB;
+import org.eyeseetea.malariacare.domain.entity.OrgUnitLevel;
+import org.hisp.dhis.client.sdk.android.api.D2;
+import org.hisp.dhis.client.sdk.models.organisationunit.OrganisationUnitLevel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+public class OrgUnitLevelSDKDhisDataSource implements IMetadataRemoteDataSource<OrgUnitLevel> {
+    @Override
+    public List<OrgUnitLevel> getAll() throws Exception {
+        List<OrganisationUnitLevel> organisationUnitLevels =
+                D2.organisationUnitLevels().pull().toBlocking().single();
+
+        return mapToDomain(organisationUnitLevels);
+    }
+
+    private List<OrgUnitLevel> mapToDomain(List<OrganisationUnitLevel> organisationUnitLevels) {
+        List<OrgUnitLevel> orgUnitLevels = new ArrayList<>();
+
+        sortByLevel(organisationUnitLevels);
+
+        for (OrganisationUnitLevel organisationUnitLevel:organisationUnitLevels) {
+            orgUnitLevels.add(new OrgUnitLevel(organisationUnitLevel.getUId(),
+                            organisationUnitLevel.getDisplayName()));
+        }
+
+        return orgUnitLevels;
+    }
+
+    private void sortByLevel(List<OrganisationUnitLevel> organisationUnitLevels) {
+        Collections.sort(organisationUnitLevels, new Comparator<OrganisationUnitLevel>() {
+            @Override
+            public int compare(
+                    OrganisationUnitLevel orgUnitLevel1,
+                    OrganisationUnitLevel orgUnitLevel2) {
+                return  new Integer(orgUnitLevel1.getLevel())
+                        .compareTo(new Integer(orgUnitLevel2.getLevel()));
+            }
+        });
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/dataSources/SurveySDKDhisDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/dataSources/SurveySDKDhisDataSource.java
@@ -17,7 +17,7 @@
  *  along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.eyeseetea.malariacare.data.remote.sdk.data;
+package org.eyeseetea.malariacare.data.remote.sdk.dataSources;
 
 import android.content.Context;
 
@@ -27,6 +27,8 @@ import org.eyeseetea.malariacare.data.database.model.CompositeScoreDB;
 import org.eyeseetea.malariacare.data.database.model.UserDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.Session;
+import org.eyeseetea.malariacare.data.remote.sdk.mapper.FromSurveyEventMapper;
+import org.eyeseetea.malariacare.data.remote.sdk.mapper.SurveyMapper;
 import org.eyeseetea.malariacare.data.sync.mappers.PushReportMapper;
 import org.eyeseetea.malariacare.domain.boundary.IConnectivityManager;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IOptionRepository;

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/mapper/EventMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/mapper/EventMapper.java
@@ -1,4 +1,4 @@
-package org.eyeseetea.malariacare.data.remote.sdk.data;
+package org.eyeseetea.malariacare.data.remote.sdk.mapper;
 
 import static org.eyeseetea.malariacare.utils.DateParser.AMERICAN_DATE_FORMAT;
 import static org.eyeseetea.malariacare.utils.DateParser.DHIS2_GMT_DATE_FORMAT;

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/mapper/FromObservationEventMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/mapper/FromObservationEventMapper.java
@@ -1,4 +1,4 @@
-package org.eyeseetea.malariacare.data.remote.sdk.data;
+package org.eyeseetea.malariacare.data.remote.sdk.mapper;
 
 import android.content.Context;
 import android.util.Log;

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/mapper/FromSurveyEventMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/mapper/FromSurveyEventMapper.java
@@ -1,4 +1,4 @@
-package org.eyeseetea.malariacare.data.remote.sdk.data;
+package org.eyeseetea.malariacare.data.remote.sdk.mapper;
 
 import android.content.Context;
 

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/mapper/SurveyMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/mapper/SurveyMapper.java
@@ -1,4 +1,4 @@
-package org.eyeseetea.malariacare.data.remote.sdk.data;
+package org.eyeseetea.malariacare.data.remote.sdk.mapper;
 
 import android.util.Log;
 

--- a/app/src/main/java/org/eyeseetea/malariacare/data/repositories/AMetadataRepository.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/repositories/AMetadataRepository.java
@@ -1,0 +1,21 @@
+package org.eyeseetea.malariacare.data.repositories;
+
+import org.eyeseetea.malariacare.domain.common.ReadPolicy;
+
+import java.util.List;
+
+public abstract class AMetadataRepository <T>{
+
+    protected abstract List<T> getAllFromCache() throws Exception;
+    protected abstract List<T> getAllFromNetworkFirst() throws Exception;
+
+    public List<T> getAll(ReadPolicy policy) throws Exception {
+        if (policy == ReadPolicy.CACHE)
+            return  getAllFromCache();
+        else if (policy == ReadPolicy.NETWORK_FIRST)
+            return getAllFromNetworkFirst();
+        else
+            throw new IllegalArgumentException(
+                    "A Metadata repository does not implement " + policy + " policy.");
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/data/repositories/OrgUnitLevelRepository.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/repositories/OrgUnitLevelRepository.java
@@ -1,0 +1,38 @@
+package org.eyeseetea.malariacare.data.repositories;
+
+import org.eyeseetea.malariacare.data.boundaries.IMetadataLocalDataSource;
+import org.eyeseetea.malariacare.data.boundaries.IMetadataRemoteDataSource;
+import org.eyeseetea.malariacare.domain.boundary.repositories.IOrgUnitLevelRepository;
+import org.eyeseetea.malariacare.domain.entity.OrgUnitLevel;
+
+import java.util.List;
+
+public class OrgUnitLevelRepository
+        extends AMetadataRepository<OrgUnitLevel>
+        implements IOrgUnitLevelRepository {
+
+    IMetadataLocalDataSource mOrgUnitLevelLocalDataSource;
+    IMetadataRemoteDataSource mOrgUnitLevelRemoteDataSource;
+
+    public OrgUnitLevelRepository(
+            IMetadataLocalDataSource orgUnitLevelLocalDataSource,
+            IMetadataRemoteDataSource orgUnitLevelRemoteDataSource){
+        mOrgUnitLevelLocalDataSource = orgUnitLevelLocalDataSource;
+        mOrgUnitLevelRemoteDataSource = orgUnitLevelRemoteDataSource;
+    }
+
+    @Override
+    protected List<OrgUnitLevel> getAllFromCache() throws Exception {
+        return (List<OrgUnitLevel>) mOrgUnitLevelLocalDataSource.getAll();
+    }
+
+    @Override
+    protected List<OrgUnitLevel> getAllFromNetworkFirst() throws Exception {
+        List<OrgUnitLevel> remoteOrgUnitLevels = (List<OrgUnitLevel>)
+                mOrgUnitLevelRemoteDataSource.getAll();
+
+        mOrgUnitLevelLocalDataSource.clearAndSave(remoteOrgUnitLevels);
+
+        return remoteOrgUnitLevels;
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/IOrgUnitLevelRepository.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/IOrgUnitLevelRepository.java
@@ -1,0 +1,10 @@
+package org.eyeseetea.malariacare.domain.boundary.repositories;
+
+import org.eyeseetea.malariacare.domain.common.ReadPolicy;
+import org.eyeseetea.malariacare.domain.entity.OrgUnitLevel;
+
+import java.util.List;
+
+public interface IOrgUnitLevelRepository {
+    List<OrgUnitLevel> getAll(ReadPolicy policy) throws Exception;
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/IQuestionRepository.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/IQuestionRepository.java
@@ -1,8 +1,6 @@
 package org.eyeseetea.malariacare.domain.boundary.repositories;
 
-import org.eyeseetea.malariacare.data.IDataSourceCallback;
 import org.eyeseetea.malariacare.domain.entity.Question;
-import org.eyeseetea.malariacare.domain.entity.Survey;
 
 import java.util.List;
 

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/common/PositiveOrCeroChecker.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/common/PositiveOrCeroChecker.java
@@ -1,4 +1,4 @@
-package org.eyeseetea.malariacare.domain.utils;
+package org.eyeseetea.malariacare.domain.common;
 
 public class PositiveOrCeroChecker {
 

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/common/ReadPolicy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/common/ReadPolicy.java
@@ -1,0 +1,7 @@
+package org.eyeseetea.malariacare.domain.common;
+
+public enum ReadPolicy {
+    CACHE,
+    NETWORK_FIRST,
+    NETWORK_NO_CACHE
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/common/RequiredChecker.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/common/RequiredChecker.java
@@ -1,4 +1,4 @@
-package org.eyeseetea.malariacare.domain.utils;
+package org.eyeseetea.malariacare.domain.common;
 
 public class RequiredChecker {
 

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/CompositeScore.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/CompositeScore.java
@@ -1,7 +1,7 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.eyeseetea.malariacare.domain.utils.PositiveOrCeroChecker.isPositiveOrCero;
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.PositiveOrCeroChecker.isPositiveOrCero;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 import java.util.ArrayList;
 

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Credentials.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Credentials.java
@@ -19,7 +19,7 @@
 
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 public class Credentials {
     private static final String DEMO_USER = "demo";

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/IMetadata.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/IMetadata.java
@@ -1,0 +1,4 @@
+package org.eyeseetea.malariacare.domain.entity;
+
+public interface IMetadata {
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Observation.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Observation.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import org.eyeseetea.malariacare.domain.utils.RequiredChecker;
+import org.eyeseetea.malariacare.domain.common.RequiredChecker;
 
 import java.util.ArrayList;
 import java.util.Date;

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/ObservationValue.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/ObservationValue.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import org.eyeseetea.malariacare.domain.utils.RequiredChecker;
+import org.eyeseetea.malariacare.domain.common.RequiredChecker;
 
 public class ObservationValue {
     private String value;

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Option.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Option.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 public class Option {
     private String uId;

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/OrgUnit.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/OrgUnit.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/OrgUnitLevel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/OrgUnitLevel.java
@@ -1,12 +1,8 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-public class OrgUnitLevel {
+public class OrgUnitLevel implements IMetadata{
     private final String uid;
     private final String name;
 

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Program.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Program.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Question.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Question.java
@@ -1,8 +1,6 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import java.util.ArrayList;
-import java.util.List;
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 public class Question {
     private String uId;

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/QuestionValue.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/QuestionValue.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 public class QuestionValue {
     private final String questionUId;

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Score.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Score.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 public class Score {
     private final String uId;

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/ScoreType.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/ScoreType.java
@@ -20,7 +20,7 @@
 package org.eyeseetea.malariacare.domain.entity;
 
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 public class ScoreType {
 

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/ServerMetadata.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/ServerMetadata.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 public class ServerMetadata {
     private final ServerMetadataItem nextAssessment;

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/ServerMetadataItem.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/ServerMetadataItem.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 public class ServerMetadataItem {
     private final String code;

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Survey.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Survey.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 import org.eyeseetea.malariacare.domain.exception.CalculateNextScheduledDateException;
 

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/UserAccount.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/UserAccount.java
@@ -21,7 +21,7 @@ package org.eyeseetea.malariacare.domain.entity;
 
 import java.util.Date;
 
-import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+import static org.eyeseetea.malariacare.domain.common.RequiredChecker.required;
 
 public class UserAccount {
     private String name;

--- a/app/src/main/java/org/eyeseetea/malariacare/factories/MetadataFactory.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/factories/MetadataFactory.java
@@ -3,14 +3,21 @@ package org.eyeseetea.malariacare.factories;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
+import org.eyeseetea.malariacare.data.boundaries.IMetadataLocalDataSource;
+import org.eyeseetea.malariacare.data.boundaries.IMetadataRemoteDataSource;
+import org.eyeseetea.malariacare.data.database.datasources.OrgUnitLevelLocalDataSource;
 import org.eyeseetea.malariacare.data.database.datasources.QuestionLocalDataSource;
+import org.eyeseetea.malariacare.data.remote.sdk.dataSources.OrgUnitLevelSDKDhisDataSource;
 import org.eyeseetea.malariacare.data.repositories.OptionRepository;
+import org.eyeseetea.malariacare.data.repositories.OrgUnitLevelRepository;
 import org.eyeseetea.malariacare.data.repositories.OrgUnitRepository;
 import org.eyeseetea.malariacare.data.repositories.ServerMetadataRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IOptionRepository;
+import org.eyeseetea.malariacare.domain.boundary.repositories.IOrgUnitLevelRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IOrgUnitRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IQuestionRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IServerMetadataRepository;
+import org.eyeseetea.malariacare.domain.entity.OrgUnitLevel;
 
 public class MetadataFactory {
     @NonNull
@@ -29,5 +36,17 @@ public class MetadataFactory {
 
     public IOrgUnitRepository getOrgUnitRepository() {
         return new OrgUnitRepository();
+    }
+
+    public IOrgUnitLevelRepository getOrgUnitLevelRepository(){
+        IMetadataLocalDataSource<OrgUnitLevel> orgUnitLocalDataSource =
+                new OrgUnitLevelLocalDataSource();
+        IMetadataRemoteDataSource <OrgUnitLevel> orgUnitLevelRemoteDataSource =
+                new OrgUnitLevelSDKDhisDataSource();
+
+        IOrgUnitLevelRepository orgUnitLevelRepository =
+                new OrgUnitLevelRepository(orgUnitLocalDataSource,orgUnitLevelRemoteDataSource);
+
+        return orgUnitLevelRepository;
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/factories/SyncFactory.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/factories/SyncFactory.java
@@ -12,13 +12,14 @@ import org.eyeseetea.malariacare.data.database.iomodules.dhis.exporter.PushDataC
 import org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.PullDataController;
 import org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.PullMetadataController;
 import org.eyeseetea.malariacare.data.network.ConnectivityManager;
-import org.eyeseetea.malariacare.data.remote.sdk.data.ObservationSDKDhisDataSource;
-import org.eyeseetea.malariacare.data.remote.sdk.data.SurveySDKDhisDataSource;
+import org.eyeseetea.malariacare.data.remote.sdk.dataSources.ObservationSDKDhisDataSource;
+import org.eyeseetea.malariacare.data.remote.sdk.dataSources.SurveySDKDhisDataSource;
 import org.eyeseetea.malariacare.domain.boundary.IConnectivityManager;
 import org.eyeseetea.malariacare.domain.boundary.IPushController;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IOptionRepository;
+import org.eyeseetea.malariacare.domain.boundary.repositories.IOrgUnitLevelRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IOrgUnitRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IQuestionRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IServerMetadataRepository;
@@ -33,7 +34,7 @@ public class SyncFactory {
     private MetadataFactory metadataFactory = new MetadataFactory();
 
     public PullUseCase getPullUseCase(Context context){
-        PullMetadataController pullMetadataController = new PullMetadataController();
+        PullMetadataController pullMetadataController = getPullMetadataController();
 
         IDataRemoteDataSource surveyRemoteDataSource = getSurveyRemoteDataSource(context);
         IDataLocalDataSource surveyLocalDataSource = getSurveyLocalDataSource();
@@ -50,6 +51,14 @@ public class SyncFactory {
                 pullDataController, metadataValidator);
 
         return pullUseCase;
+    }
+
+    @NonNull
+    private PullMetadataController getPullMetadataController() {
+        IOrgUnitLevelRepository orgUnitLevelRepository =
+                metadataFactory.getOrgUnitLevelRepository();
+
+        return new PullMetadataController(orgUnitLevelRepository);
     }
 
     public PushUseCase getPushUseCase(Context context){

--- a/app/src/test/java/org/eyeseetea/malariacare/data/remote/sdk/dataSources/SurveyMapperShould.java
+++ b/app/src/test/java/org/eyeseetea/malariacare/data/remote/sdk/dataSources/SurveyMapperShould.java
@@ -1,4 +1,4 @@
-package org.eyeseetea.malariacare.data.remote.sdk.data;
+package org.eyeseetea.malariacare.data.remote.sdk.dataSources;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -13,6 +13,7 @@ import org.eyeseetea.malariacare.common.DateTimeTypeAdapter;
 import org.eyeseetea.malariacare.common.DateTypeAdapter;
 import org.eyeseetea.malariacare.common.ResourcesFileReader;
 import org.eyeseetea.malariacare.data.database.model.CompositeScoreDB;
+import org.eyeseetea.malariacare.data.remote.sdk.mapper.SurveyMapper;
 import org.eyeseetea.malariacare.domain.entity.Option;
 import org.eyeseetea.malariacare.domain.entity.OrgUnit;
 import org.eyeseetea.malariacare.domain.entity.Question;


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close  #2160 
* **Related pull-requests:** 

### :tophat: What is the goal?

The goal is uncoupled pull of orgUnitLevel from Dhis 2 SDK.

### :memo: How is it being implemented?

 - Creating the repository OrgUnitLevel, this repository according to a ReadPolicy decide to invoke to LocalDataSource or RemoteDataSource. When Network first is invoked then save the result in LocalDataSource. This one clear (delete all) previously the local table.

**Important**: For the moment, OrgUnitLevelRepository is invoked from PullMetadataDataSource but on the future, this controller should be removed and move repositories invokes to use case (More Clean Architecture).

### :boom: How can it be tested?

- [ ] **Use case 1:** Create a breakpoint in line 75 of PullMetadataController, Realize Login and wait until execution stop in breakpoint, then verify after invoke mOrgUnitLevelRepository.getAll(ReadPolicy.NETWORK_FIRST) that the org units levels are downloaded successfully.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-