### PR TITLE
Feature add date type changes

### DIFF
--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/AssessAction/AssessCompleteGoToImprove.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/AssessAction/AssessCompleteGoToImprove.java
@@ -106,9 +106,9 @@ public class AssessCompleteGoToImprove {
         IdlingResource idlingResource = new ElapsedTimeIdlingResource(5 * 1000);
         Espresso.registerIdlingResources(idlingResource);
         try {
-            onView(withText(String.valueOf(AUtils.formatDate(completionDate)))).check(matches(isDisplayed()));
+            onView(withText(String.valueOf(AUtils.scheduleFormatDate(completionDate)))).check(matches(isDisplayed()));
         }catch(AmbiguousViewMatcherException e){
-            Log.i(TAG, "Multiple surveys have the same date " + AUtils.formatDate(completionDate));
+            Log.i(TAG, "Multiple surveys have the same date " + AUtils.scheduleFormatDate(completionDate));
         }
         try {
             onView(withText(String.format("%.1f %%", survey.getMainScore()))).check(matches(isDisplayed()));

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/planning/ScheduleListener.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/planning/ScheduleListener.java
@@ -69,7 +69,7 @@ public class ScheduleListener implements View.OnClickListener {
         //Set current date
         final CustomEditText scheduleDatePickerButton=(CustomEditText)dialog.findViewById(R.id.planning_dialog_picker_button);
         final Date surveyDefaultDate = survey.getScheduledDate();
-        scheduleDatePickerButton.setText(AUtils.formatDate(surveyDefaultDate));
+        scheduleDatePickerButton.setText(AUtils.scheduleFormatDate(surveyDefaultDate));
         //On Click open an specific DatePickerDialog
         scheduleDatePickerButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -86,7 +86,7 @@ public class ScheduleListener implements View.OnClickListener {
                         Calendar newCalendar = Calendar.getInstance();
                         newCalendar.set(year, monthOfYear, dayOfMonth);
                         newScheduledDate = newCalendar.getTime();
-                        scheduleDatePickerButton.setText(AUtils.formatDate(newScheduledDate));
+                        scheduleDatePickerButton.setText(AUtils.scheduleFormatDate(newScheduledDate));
                     }
 
                 },calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH)).show();

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/AutoTabAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/AutoTabAdapter.java
@@ -519,9 +519,9 @@ public class AutoTabAdapter extends ATabAdapter {
         switch (question.getOutput()) {
             case Constants.DATE:
                 String valueString=ReadWriteDB.readValueQuestion(question, module);
-                Date valueDate= EventExtended.parseLongDate(valueString);
+                String valueDate = AUtils.userFormatDate(EventExtended.parseLongDate(valueString));
                 if(valueDate!=null) {
-                    viewHolder.setText(ReadWriteDB.readValueQuestion(question, module));
+                    viewHolder.setText(valueDate);
                 }
                 break;
             case Constants.SHORT_TEXT:
@@ -757,8 +757,13 @@ public class AutoTabAdapter extends ATabAdapter {
                     newCalendar.set(year, monthOfYear, dayOfMonth);
                     Date newScheduledDate = newCalendar.getTime();
                     if(!isCleared) {
-                        ((CustomButton) v).setText( AUtils.formatDate(newCalendar.getTime()));
-                        ReadWriteDB.saveValuesText(question, AUtils.formatDate(newCalendar.getTime()), module);
+                        ((CustomButton) v).setText( AUtils.userFormatDate(newCalendar.getTime()));
+                        ReadWriteDB.saveValuesText(question, AUtils.formatDateToServer(newCalendar.getTime()), module);
+                    }else{
+                        String date = ReadWriteDB.readValueQuestion(question, module);
+                        if(date!=null && !date.isEmpty()){
+                            ((CustomButton) v).setText( AUtils.userFormatDate(EventExtended.parseShortDate(date)));
+                        }
                     }
                     isCleared =false;
                 }

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/AUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/AUtils.java
@@ -40,6 +40,7 @@ import com.raizlabs.android.dbflow.structure.BaseModel;
 import org.eyeseetea.malariacare.BuildConfig;
 import org.eyeseetea.malariacare.DashboardActivity;
 import org.eyeseetea.malariacare.R;
+import org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.models.EventExtended;
 import org.eyeseetea.malariacare.data.database.model.CompositeScoreDB;
 import org.eyeseetea.malariacare.data.database.model.HeaderDB;
 import org.eyeseetea.malariacare.data.database.model.QuestionDB;
@@ -181,10 +182,21 @@ public abstract class AUtils {
         return sdf.format(date);
     }
 
-    public static String formatDate(Date date) {
+    public static String userFormatDate(Date date) {
+        if (date == null) {
+            return "";
+        }
+        return formatDate(date);
+    }
+
+    public static String scheduleFormatDate(Date date) {
         if (date == null) {
             return "-";
         }
+        return formatDate(date);
+    }
+
+    private static String formatDate(Date date) {
         Locale locale =
                 PreferencesState.getInstance().getContext().getResources().getConfiguration()
                         .locale;
@@ -196,13 +208,9 @@ public abstract class AUtils {
         if (date == null) {
             return "";
         }
-        Locale locale =
-                PreferencesState.getInstance().getContext().getResources().getConfiguration()
-                        .locale;
-        DateFormat dateFormatter = DateFormat.getDateInstance(DateFormat.DEFAULT, locale);
 
-
-        return dateFormatter.format(date);
+        return EventExtended.format(date,
+                EventExtended.AMERICAN_DATE_FORMAT);
     }
 
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2181

### :tophat: What is the goal?

Fix bugs with Date types in v1.4

The date type does not show the value saved in the survey fragment
When push the value the server returns conflict status 

### :memo: How is it being implemented?

Cherry-pick from the commits on ( https://github.com/EyeSeeTea/malariapp/pull/2183 )
Refactor some names.
In the datepicker:
Save the date value as server formatted value in database.
Convert the date value to human readable format before show.

Loading values:
fix wrong code and convert the date to human readable format.

### :boom: How can it be tested?

To test in leap ou will need modify a dataelement to set as date type.
I changed a dataElement of Cervical cancer program

https://leap.psi-mis.org/dhis-web-maintenance/#/edit/dataElementSection/dataElement/uzeNUvOyzJL
 
Option set -> no value
Value type -> Date
20 Question Type -> Date

 **Use case 1:** Save a date value, close survey, open survey, and check the date value is shown.
 **Use case 2:** Save a date value, move the scroll, and check the date value is shown
 **Use case 3:** Save a date value, do a push, and check if the date value is pushed
 **Use case 4:** Save a date value, clean it, do a push, and check the date value is not pushed

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-