### PR TITLE
Modify text for string url_not_available

### DIFF
--- a/app/src/eyeseetea/res/values-es/strings.xml
+++ b/app/src/eyeseetea/res/values-es/strings.xml
@@ -254,7 +254,7 @@ clínica"</string>
 </string-array>
 <string name="supervision_on">Supervisión de resultados en:</string>
 <string name="critical_steps">Pasos críticos perdidos:</string>
-<string name="url_not_available">URL aún no disponible</string>
+<string name="url_not_available">La URL de comentarios no está disponible porque la encuesta aún no se ha enviado al servidor. Intenta compartir los comentarios de nuevo más tarde.</string>
 <string name="see_full_assessment">Ver evaluación completa en:</string>
 <string name="on">"en"</string>
 

--- a/app/src/eyeseetea/res/values-fr/strings.xml
+++ b/app/src/eyeseetea/res/values-fr/strings.xml
@@ -245,7 +245,7 @@ Mensuelle"</string>
 </string-array>
 <string name="supervision_on">"Surveillance des résultats sur:"</string>
 <string name="critical_steps">"Étapes critiques manquées:"</string>
-<string name="url_not_available">"L'URL n'est pas encore disponible"</string>
+<string name="url_not_available">"L'URL de commentaires n'est pas disponible car l'enquête n'a pas encore été envoyée au serveur. Essayez de partager les commentaires plus tard."</string>
 <string name="see_full_assessment">"Voir l'évaluation complète à:"</string>
 <string name="on">"à"</string>
 

--- a/app/src/eyeseetea/res/values-km/strings.xml
+++ b/app/src/eyeseetea/res/values-km/strings.xml
@@ -260,7 +260,7 @@ evaluation"</string>
 </string-array>
 <string name="supervision_on">ការត្រួតពិនិត្យលទ្ធផលលើ:</string>
 <string name="critical_steps">ជំហានរិះគន់ខកខាន:</string>
-<string name="url_not_available">URL មិនទាន់មានទេ</string>
+<string name="url_not_available">URL ឆ្លើយតបមិនមានទេពីព្រោះការស្ទង់មតិមិនត្រូវបានផ្ញើទៅម៉ាស៊ីនមេនៅឡើយទេ។ ព្យាយាមចែករំលែកមតិត្រឡប់ម្តងទៀតពេលក្រោយ។</string>
 <string name="see_full_assessment">មើលការវាយតម្លៃពេញលេញនៅ</string>
 <string name="pref_header_general">General</string>
 <string name="install_file_manager">សូមដំឡើងកម្មវិធីគ្រប់គ្រងឯកសារមួយ។</string>

--- a/app/src/eyeseetea/res/values-lo/strings.xml
+++ b/app/src/eyeseetea/res/values-lo/strings.xml
@@ -261,7 +261,7 @@
 </string-array>
 <string name="supervision_on">ຜົນການຊີ້ນໍາກ່ຽວກັບ:</string>
 <string name="critical_steps">ຂັ້ນຕອນສໍາຄັນທີ່ພາດໂອກາດນີ້:</string>
-<string name="url_not_available">URL ບໍ່ສາມາດໃຊ້ໄດ້</string>
+<string name="url_not_available">URL ຄວາມຄິດເຫັນບໍ່ສາມາດໃຊ້ໄດ້ເພາະວ່າການສໍາຫຼວດບໍ່ໄດ້ຖືກສົ່ງໄປຍັງເຄື່ອງແມ່ຂ່າຍ. ລອງແບ່ງປັນຄວາມຄິດເຫັນຕໍ່ອີກເທື່ອຫນຶ່ງ.</string>
 <string name="see_full_assessment">ເບິ່ງການປະເມີນຜົນເຕັມທີ່ຢູ່</string>
 <string name="on">""</string>
 

--- a/app/src/eyeseetea/res/values-pt/strings.xml
+++ b/app/src/eyeseetea/res/values-pt/strings.xml
@@ -250,7 +250,7 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 </string-array>
 <string name="supervision_on">Supervisão de resultados em:</string>
 <string name="critical_steps">Passos críticos perdidos:</string>
-<string name="url_not_available">O URL de comentários não está disponível porque a pesquisa ainda não foi enviada para o servidor. Tente compartilhar o feedback novamente mais tarde.</string>
+    <string name="url_not_available">O URL de comentários não está disponível porque a pesquisa ainda não foi enviada para o servidor. Tente compartilhar o feedback novamente mais tarde.</string>
 <string name="see_full_assessment">Veja a avaliação completa em:</string>
 <string name="on">"em"</string>
 

--- a/app/src/eyeseetea/res/values-pt/strings.xml
+++ b/app/src/eyeseetea/res/values-pt/strings.xml
@@ -250,7 +250,7 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 </string-array>
 <string name="supervision_on">Supervisão de resultados em:</string>
 <string name="critical_steps">Passos críticos perdidos:</string>
-<string name="url_not_available">URL ainda não disponível</string>
+<string name="url_not_available">O URL de comentários não está disponível porque a pesquisa ainda não foi enviada para o servidor. Tente compartilhar o feedback novamente mais tarde.</string>
 <string name="see_full_assessment">Veja a avaliação completa em:</string>
 <string name="on">"em"</string>
 

--- a/app/src/eyeseetea/res/values/strings.xml
+++ b/app/src/eyeseetea/res/values/strings.xml
@@ -251,7 +251,7 @@ evaluation"</string>
 </string-array>
 <string name="supervision_on">Results supervision on:</string>
 <string name="critical_steps">Critical Steps missed:</string>
-<string name="url_not_available">"URL not yet available"</string>
+<string name="url_not_available">"The feedback URL is not available because the survey hasn't been sent to the server yet. Try sharing the feedback again later."</string>
 <string name="see_full_assessment">"See full assessment at:"</string>
 
 <string name="install_file_manager">Please install a File Manager.</string>

--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -256,7 +256,7 @@ clínica"</string>
 </string-array>
 <string name="supervision_on">Supervisión de resultados en:</string>
 <string name="critical_steps">PASOS CRÍTICOS PERDIDOS:</string>
-<string name="url_not_available">URL aún no disponible</string>
+<string name="url_not_available">La URL de comentarios no está disponible porque la encuesta aún no se ha enviado al servidor. Intenta compartir los comentarios de nuevo más tarde.</string>
 <string name="see_full_assessment">Ver evaluación completa en:</string>
 <string name="on">"FECHA DE EVALUACIÓN:"</string>
 

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -246,7 +246,7 @@ Mensuelle"</string>
 </string-array>
 <string name="supervision_on">"Surveillance des résultats sur:"</string>
 <string name="critical_steps">ÉTAPES CRITIQUES MANQUÉES:</string>
-<string name="url_not_available">"L'URL n'est pas encore disponible"</string>
+<string name="url_not_available">"L'URL de commentaires n'est pas disponible car l'enquête n'a pas encore été envoyée au serveur. Essayez de partager les commentaires plus tard."</string>
 <string name="see_full_assessment">"Voir l'enquête complète à:"</string>
 <string name="on">"DATE D'ÉVALUATION:"</string>
 

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -263,7 +263,7 @@
 </string-array>
 <string name="supervision_on">ការត្រួតពិនិត្យលទ្ធផលលើ:</string>
 <string name="critical_steps">ជំហានរិះគន់ខកខាន:</string>
-<string name="url_not_available">URL មិនទាន់មានទេ</string>
+<string name="url_not_available">URL ឆ្លើយតបមិនមានទេពីព្រោះការស្ទង់មតិមិនត្រូវបានផ្ញើទៅម៉ាស៊ីនមេនៅឡើយទេ។ ព្យាយាមចែករំលែកមតិត្រឡប់ម្តងទៀតពេលក្រោយ។</string>
 <string name="see_full_assessment">មើលការស្ទង់មតិពេញលេញនៅ</string>
 <string name="pref_header_general">General</string>
 <string name="install_file_manager">សូមដំឡើងកម្មវិធីគ្រប់គ្រងឯកសារមួយ។</string>

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -263,7 +263,7 @@
 </string-array>
 <string name="supervision_on">ຜົນການຊີ້ນໍາກ່ຽວກັບ:</string>
 <string name="critical_steps">ຂັ້ນຕອນສໍາຄັນທີ່ພາດໂອກາດນີ້:</string>
-<string name="url_not_available">URL ບໍ່ສາມາດໃຊ້ໄດ້</string>
+<string name="url_not_available">URL ຄວາມຄິດເຫັນບໍ່ສາມາດໃຊ້ໄດ້ເພາະວ່າການສໍາຫຼວດບໍ່ໄດ້ຖືກສົ່ງໄປຍັງເຄື່ອງແມ່ຂ່າຍ. ລອງແບ່ງປັນຄວາມຄິດເຫັນຕໍ່ອີກເທື່ອຫນຶ່ງ.</string>
 <string name="see_full_assessment">ເບິ່ງການສໍາຫຼວດຢ່າງເຕັມທີ່ຢູ່:</string>
 <string name="on">"ວັນທີຂອງການປະເມີນ:"</string>
 

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -252,7 +252,7 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 </string-array>
 <string name="supervision_on">Supervisão de resultados em:</string>
 <string name="critical_steps">PASSOS CRÍTICOS PERDIDOS:</string>
-<string name="url_not_available">URL ainda não disponível</string>
+<string name="url_not_available">O URL de comentários não está disponível porque a pesquisa ainda não foi enviada para o servidor. Tente compartilhar o feedback novamente mais tarde.</string>
 <string name="see_full_assessment">Veja a pesquisa completa em:</string>
 <string name="on">"DATA DE AVALIAÇÃO"</string>
 

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -252,7 +252,7 @@ evaluation"</string>
 </string-array>
 <string name="supervision_on">Results supervision on:</string>
 <string name="critical_steps">CRITICAL STEPS MISSED:</string>
-<string name="url_not_available">"URL not yet available"</string>
+<string name="url_not_available">"The feedback URL is not available because the survey hasn't been sent to the server yet. Try sharing the feedback again later."</string>
 <string name="see_full_assessment">"See full survey at:"</string>
 
 <string name="install_file_manager">Please install a File Manager.</string>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2221 
* **Related pull-requests:** 

###   :gear: branches 
**app**: 
       Origin: maintenance-modify_text_for_string_url_not_available Target: v1.4_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version 
**EyeSeeTea-SDK**: 
       Origin: development
**SDK**: 
       Origin: featutre-2.30_upgrade_gradle

### :tophat: What is the goal?

Modify text for url_not_available

### :memo: How is it being implemented?

I have modified text for all strings

### :boom: How can it be tested?

 **Use case 1:** - Realize login, create a new survey and new feedback before survey be sent then share feedback, the text 'The feedback URL is not available because the survey hasn't been sent to the server yet. Try sharing the feedback again later' should appear at the end of the text.

### :floppy_disk: Requires DB migration?

- [ ] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [x] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-