### PR TITLE
Feature fix api calls with missing slash

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/OkHttpClientDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/OkHttpClientDataSource.java
@@ -26,13 +26,23 @@ public class OkHttpClientDataSource {
 
     /**
      * Call to DHIS Server
-     * @param data
-     * @param method
+     * @param apiCall
+     */
+    public static Response executeCall(String apiCall) throws IOException {
+        return executeCall(new BasicAuthenticator(PreferencesState.getInstance().getCreedentials()), PreferencesState.getInstance().getServer().getUrl(), apiCall);
+    }
+
+    /**
+     * Call to DHIS Server
      * @param url
      */
-    public static Response executeCall(BasicAuthenticator basicAuthenticator, JSONObject data, String url, String method) throws IOException {
-
-        Log.d(TAG, "executeCall Url" + url + "");
+    public static Response executeCall(BasicAuthenticator basicAuthenticator, String url, String apiCall) throws IOException {
+        if (!url.substring(url.length()).equals("/")) {
+            url = url + "/";
+        }
+        url = url + apiCall;
+        url = url.replace(" ", "%20");
+        Log.d(TAG, "executeCall Url " + url + "");
 
         OkHttpClient client= UnsafeOkHttpsClientFactory.getUnsafeOkHttpClient();
 
@@ -46,23 +56,7 @@ public class OkHttpClientDataSource {
                 .header(basicAuthenticator.AUTHORIZATION_HEADER, basicAuthenticator.getCredentials())
                 .url(url);
 
-        switch (method){
-            case "POST":
-                RequestBody postBody = RequestBody.create(JSON, data.toString());
-                builder.post(postBody);
-                break;
-            case "PUT":
-                RequestBody putBody = RequestBody.create(JSON, data.toString());
-                builder.put(putBody);
-                break;
-            case "PATCH":
-                RequestBody patchBody = RequestBody.create(JSON, data.toString());
-                builder.patch(patchBody);
-                break;
-            case "GET":
-                builder.get();
-                break;
-        }
+        builder.get();
 
         Request request = builder.build();
         Response response = client.newCall(request).execute();
@@ -71,20 +65,6 @@ public class OkHttpClientDataSource {
             throw new IOException(response.message());
         }
         return response;
-    }
-
-    /**
-     * Call to DHIS Server
-     * @param url
-     * @param method
-     */
-    public static Response executeCall(String url, String method) throws IOException {
-        final String DHIS_URL=PreferencesState.getInstance().getServer().getUrl() + url.replace(" ", "%20");
-        return executeCall(new BasicAuthenticator(PreferencesState.getInstance().getCreedentials()), null, DHIS_URL + url, method);
-    }
-
-    public static Response executeCall(BasicAuthenticator basicAuthenticator, String url, String method) throws IOException {
-        return executeCall(basicAuthenticator, null, url, method);
     }
 
     public static JsonNode parseResponse(String responseData)throws Exception{

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/OkHttpClientDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/OkHttpClientDataSource.java
@@ -37,7 +37,7 @@ public class OkHttpClientDataSource {
      * @param url
      */
     public static Response executeCall(BasicAuthenticator basicAuthenticator, String url, String apiCall) throws IOException {
-        if (!url.substring(url.length()).equals("/")) {
+        if (!url.substring(url.length()-1).equals("/")) {
             url = url + "/";
         }
         url = url + apiCall;

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/PullDhisApiDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/PullDhisApiDataSource.java
@@ -25,10 +25,10 @@ import static org.eyeseetea.malariacare.data.remote.api.OkHttpClientDataSource.p
 
 public class PullDhisApiDataSource {
 
-    private static final String DHIS_PULL_API="/api/";
+    private static final String DHIS_PULL_API="api/";
 
     private static final String DHIS_CHECK_EVENT_API =
-            "/api/events.json?program=%s&orgUnit=%s&startDate=%s&endDate=%s&skipPaging=true"
+            "api/events.json?program=%s&orgUnit=%s&startDate=%s&endDate=%s&skipPaging=true"
                     + "&fields=event,orgUnit,program,dataValues";
 
     private static String QUERY_USER_ATTRIBUTES =

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/PullDhisApiDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/PullDhisApiDataSource.java
@@ -53,7 +53,7 @@ public class PullDhisApiDataSource {
         String data = USER + String.format(QUERY_USER_ATTRIBUTES, appUser.getUid());
         Log.d(TAG, String.format("getUserAttributesApiCall(%s) -> %s", USER, data));
         try {
-            Response response = executeCall(DHIS_PULL_API+data, "GET");
+            Response response = executeCall(DHIS_PULL_API+data);
             JsonNode jsonNode = parseResponse(response.body().string());
             JsonNode jsonNodeArray = jsonNode.get(ATTRIBUTEVALUES);
             String newMessage = "";
@@ -117,7 +117,7 @@ public class PullDhisApiDataSource {
 
         Date closedDate = null;
         try {
-            Response response = executeCall(DHIS_PULL_API+data, "GET");
+            Response response = executeCall(DHIS_PULL_API+data);
             JsonNode jsonNode = parseResponse(response.body().string());
             closedDate = getClosedDate(jsonNode.get(ATTRIBUTEVALUES));
         } catch (Exception ex) {
@@ -143,7 +143,7 @@ public class PullDhisApiDataSource {
     }
 
     public static List<EventExtended> pullQuarantineEvents(String url) throws IOException, JSONException {
-        Response response = executeCall(url, "GET");
+        Response response = executeCall(url);
         JSONObject events = new JSONObject(response.body().string());
         ObjectMapper mapper = new ObjectMapper();
         JsonNode jsonNode = mapper.convertValue(mapper.readTree(events.toString()),

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/ServerInfoDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/ServerInfoDataSource.java
@@ -34,7 +34,7 @@ public class ServerInfoDataSource implements IServerInfoDataSource {
     public static Integer getServerVersion(Credentials credentials) {
         Integer version = null;
         try {
-            Response response = executeCall(new BasicAuthenticator(credentials), credentials.getServerURL() + SERVER_VERSION_CALL, "GET");
+            Response response = executeCall(new BasicAuthenticator(credentials), credentials.getServerURL(), SERVER_VERSION_CALL);
             JsonNode jsonNode = parseResponse(response.body().string());
             JsonNode jsonVersionNode = jsonNode.get(VERSION);
             String[] completedVersionParts = jsonVersionNode.asText().split(Pattern.quote("."));


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2228 and close #2229 


###   :gear: branches 
**app**: 
       Origin: feature-fix_api_calls_with_missing_slash Target: v1.3_hnqis
**bugshaker-android**: 
Origin: downgrade_gradle_version
**dhis2-light-sdk**: 
Origin: development
**EyeSeeTea-SDK**: 
Origin: development
**SDK**: 
Origin: 2.25_EyeSeeTea

### :tophat: What is the goal?
Add / at the end of the URL only when needed
quarantine check URL is failing 

### :memo: How is it being implemented?

Note: I did the two issues at the same time because when I refactorized executecall methods to make it simple the quarantine error was solved.

The problem with quarantine check was in an error adding the data to the server in the executecall methods. (url+data+data). I removed that error refactoring to complete the other issue.

- I have added a slash on the URL in the server string when the user doesn't include the final "/"

- I have removed all the API methods switch and param because we are only using the "get" method.

- I have removed all the starter slash in the API methods.

### :boom: How can it be tested?

** Use case 1: ** - Realize login with https://data.psi-mis.org and you should login ok

 ** Use case 2: ** - Realize login with https://data.psi-mis.org/ and you should login ok

 ** Use case 3: ** - Do push and check the checkQuarantine call on the log is success.
Note: In v1.3_hnqis if a push fails the next push is in 30 mins... You can change it in
private static final long PUSH_FAIL_PERIOD = 300L;
To provoke the checkQuarantine API call do a push with a breakpoint in PushController line 170. When the debugger move to the breakpoint close the app, and reopen.
Check the log to see the events API call.
You will show some similar than:

 ```
executeCall Url https://data.psi-mis.org/api/events.json?program=mZ0zJcGODwD&orgUnit=A5HZNrJc2ir&startDate=2019-01-17&endDate=2019-01-25&skipPaging=true&fields=event,orgUnit,program,dataValues

D/.CheckSurveysB&D: Set quarantine survey as complete 818 date 2019-01-17T11:31:04.011+0000

D/org.eyeseetea.malariacare.data.database.model.SurveyDBB&D: Id: 818 actual status:1 set as:1
```

### :floppy_disk: Requires DB migration?

- [ ] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [x] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-