### PR TITLE
Feature add zwclone server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-28.0.0
+  - build-tools-28.0.3
   - android-28
   - android-27
   - android-26

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
@@ -496,9 +496,7 @@ public class PreferencesState {
     }
 
     private int[] getMonthArray(String serverUrl) {
-        if(!(serverUrl.substring(serverUrl.length()-1)).equals("/")){
-            serverUrl = serverUrl+"/";
-        }
+        serverUrl = formatUrl(serverUrl);
 
         if(nextScheduleMonths.containsKey(serverUrl))
         {
@@ -506,6 +504,13 @@ public class PreferencesState {
         } else {
             return nextScheduleMonths.get(DEFAULT_SCHEDULE_MONTHS_VALUE);
         }
+    }
+
+    private String formatUrl(String serverUrl) {
+        if(!(serverUrl.substring(serverUrl.length()-1)).equals("/")){
+            serverUrl = serverUrl+"/";
+        }
+        return serverUrl;
     }
 
     private String getServerUrl() {

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
@@ -47,7 +47,7 @@ import java.util.Map;
 
 public class PreferencesState {
 
-    public static final String DEFAULT_SCHEDULE_MONTHS_VALUE ="https://data.psi-mis.org";
+    public static final String DEFAULT_SCHEDULE_MONTHS_VALUE ="https://data.psi-mis.org/";
     public static final HashMap<String, int[]> nextScheduleMonths = new HashMap<>();
 
     static {
@@ -496,6 +496,10 @@ public class PreferencesState {
     }
 
     private int[] getMonthArray(String serverUrl) {
+        if(!(serverUrl.substring(serverUrl.length()-1)).equals("/")){
+            serverUrl = serverUrl+"/";
+        }
+
         if(nextScheduleMonths.containsKey(serverUrl))
         {
             return nextScheduleMonths.get(serverUrl);

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
@@ -53,6 +53,7 @@ public class PreferencesState {
     static {
         nextScheduleMonths.put(DEFAULT_SCHEDULE_MONTHS_VALUE, new int[]{2, 4, 6});
         nextScheduleMonths.put("https://zw.hnqis.org/", new int[]{1, 1, 6});
+        nextScheduleMonths.put("https://clone-zw.hnqis.org/", new int[]{1, 1, 6});
     }
 
     static Context context;

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -145,6 +145,7 @@
         <item>https://singapore-dev.psi-mis.org/</item>
         <item>https://zw.hnqis.org/</item>
         <item>https://clone-zw.hnqis.org/</item>
+        <item>https://clone.psi-mis.org/</item>
         <item>@string/other</item>
     </string-array>
     <string name="server_version_preference" translatable="false">server_version_preference</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -144,6 +144,7 @@
         <item>https://sfhnigeria.psi-mis.org/</item>
         <item>https://singapore-dev.psi-mis.org/</item>
         <item>https://zw.hnqis.org/</item>
+        <item>https://clone-zw.hnqis.org/</item>
         <item>@string/other</item>
     </string-array>
     <string name="server_version_preference" translatable="false">server_version_preference</string>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2233


###   :gear: branches 
**app**: 
       Origin: feature-add_zwclone_server Target: v1.4_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version 
**dhis2-light-sdk**:
       Origin: development
**EyeSeeTea-SDK**: 
       Origin: development
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

https://clone-zw.hnqis.org is not present in 1.4. It should be present and with the prioritization matrix +1, +1, +6 months for ZW server

### :memo: How is it being implemented?

- I have added psi and zw clone servers.
- I have fixed a wrong url format on default matrix url.

### :boom: How can it be tested?
Check the new servers in the dropdown.
You can debug the PreferenceState getServer method and check if the nextScheduleMonths are correct.


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-