### PR TITLE
Maintenance old android versions login dropdown colors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -223,10 +223,10 @@ dependencies {
     compile "com.squareup:javapoet:${libs.javapoetVersion}"
 
     //DBFlow
-    annotationProcessor "com.github.Raizlabs.DBFlow:dbflow-processor:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow-core:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow-sqlcipher:${libs.dbFlowVersion}"
+    annotationProcessor "com.github.agrosner.dbflow:dbflow-processor:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow-core:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow-sqlcipher:${libs.dbFlowVersion}"
     // Instrumented tests dependencies
     androidTestCompile "com.squareup.okhttp3:mockwebserver:${libs.mockwebserverVersion}"
     androidTestCompile "org.mockito:mockito-core:${libs.mockitoVersion}"

--- a/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
@@ -126,7 +126,7 @@ public class LoginActivity extends AbsLoginActivity {
         if(serverList.length<1) {
             return;
         }
-        ArrayAdapter serversListAdapter = new ArrayAdapter<>(getBaseContext(),android.R.layout.simple_spinner_item, serverList);
+        ArrayAdapter serversListAdapter = new ArrayAdapter<>(getBaseContext(),R.layout.simple_spinner_item, serverList);
         serverSpinner.setAdapter(serversListAdapter);
         serverSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2243  
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance-old_android_versions_login_dropdown_colors Target: v1.4_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Render with good color contrast server spinner in old devices

### :memo: How is it being implemented?

- Replace from android.R.layout.simple_spinner_item to R.layout.simple_spinner_item the parameter to create ArrayAdapter

### :boom: How can it be tested?

 **Use case 1:** - Execute the app in an old device and spinner should render sucessfully

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-