### PR TITLE
Maintenance replace plan by org unit list view to recycler view

### DIFF
--- a/app/src/hnqis/res/layout/assessment_planning_record.xml
+++ b/app/src/hnqis/res/layout/assessment_planning_record.xml
@@ -21,7 +21,7 @@
 <TableRow xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:id="@+id/assessment_row"
     android:background="@drawable/cell_borders">
 

--- a/app/src/main/res/layout/assessment_planning_record.xml
+++ b/app/src/main/res/layout/assessment_planning_record.xml
@@ -21,7 +21,7 @@
 <TableRow xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:id="@+id/assessment_row"
     android:background="@drawable/cell_borders">
 

--- a/app/src/main/res/layout/plan_per_org_unit_list.xml
+++ b/app/src/main/res/layout/plan_per_org_unit_list.xml
@@ -4,23 +4,25 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
-        <LinearLayout
-            android:id="@+id/header"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/planning_header_background"
-            android:orientation="horizontal">
+
+    <LinearLayout
+        android:id="@+id/header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/planning_header_background"
+        android:orientation="horizontal">
+
         <RelativeLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="0.9"
             android:layout_alignParentTop="true"
             android:layout_gravity="center_vertical"
-            android:minHeight="@dimen/header_min_height"
-            android:padding="8dp"
+            android:layout_weight="0.9"
             android:background="@color/planning_header_background"
             android:gravity="center"
-            android:orientation="vertical">
+            android:minHeight="@dimen/header_min_height"
+            android:orientation="vertical"
+            android:padding="8dp">
 
             <org.eyeseetea.malariacare.views.CustomCheckBox
                 android:id="@+id/select_all_orgunits"
@@ -53,25 +55,27 @@
                 app:tFontName="@string/light_font" />
         </RelativeLayout>
 
-            <ImageButton
-                android:id="@+id/reschedule_button"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.1"
-                android:layout_gravity="center_horizontal"
-                android:minHeight="@dimen/header_min_height"
-                android:gravity="center_horizontal"
-                android:background="@color/planning_header_background"
-                android:src="@drawable/ic_calendar"
-                android:paddingRight="2dp"
-                android:scaleType="fitCenter"
-                android:textColor="@color/white"
-                android:textSize="@dimen/medium_text_size"
-                android:textStyle="bold" />
-        </LinearLayout>
-        <ListView
-            android:id="@id/android:list"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_below="@id/header" />
+        <ImageButton
+            android:id="@+id/reschedule_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_weight="0.1"
+            android:background="@color/planning_header_background"
+            android:gravity="center_horizontal"
+            android:minHeight="@dimen/header_min_height"
+            android:paddingRight="2dp"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_calendar"
+            android:textColor="@color/white"
+            android:textSize="@dimen/medium_text_size"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/planByOrgUnitList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layoutManager="android.support.v7.widget.LinearLayoutManager"
+        android:layout_below="@id/header"/>
 </RelativeLayout>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2253   
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance-replace_plan_by_org_unit_list_view_to_recycler_view Target: v1.4_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Replace from planned per org unit surveys listview to recyclerView

### :memo: How is it being implemented?

- I have refactored PlannedPerOrgUnitFragment to extend from a simple Fragment
- I have modified the layout with RecyclerView
- I have refactored PlanningPerOrgUnitAdapter to extends from RecyclerView.Adapter, I have created a view holder

### :boom: How can it be tested?

 **Use case 1:** - Execute the app and the by org unit plan tab should work like the last version.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-