### PR TITLE
Feature show new score classification in observations

### DIFF
--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -124,7 +124,7 @@ clínica"</string>
 <string name="feedback_show_only_one_or_show_all">"Mostrar sólo la última respuesta por programa/unidad organizativa"</string>
 <string name="feedback_return">"Volver a todas las encuestas"</string>
 <string name="quality_of_care">"CALIDAD DE LA ASISTENCIA (QoC) PUNTUACIÓN:"</string>
-<string name="overall_quality_of_care">"Puntuación general de calidad de atención (QoC):"</string>
+<string name="overall_quality_of_care">"QoC:"</string>
 <string name="feedback_info_passed">"Aprobado"</string>
 <string name="feedback_info_failed">"Suspenso"</string>
 <string name="feedback_info_not_answered">"Sin respuesta"</string>

--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -124,7 +124,7 @@ clínica"</string>
 <string name="feedback_show_only_one_or_show_all">"Mostrar sólo la última respuesta por programa/unidad organizativa"</string>
 <string name="feedback_return">"Volver a todas las encuestas"</string>
 <string name="quality_of_care">"CALIDAD DE LA ASISTENCIA (QoC) PUNTUACIÓN:"</string>
-<string name="overall_quality_of_care">"QoC:"</string>
+<string name="overall_quality_of_care">"QoC"</string>
 <string name="feedback_info_passed">"Aprobado"</string>
 <string name="feedback_info_failed">"Suspenso"</string>
 <string name="feedback_info_not_answered">"Sin respuesta"</string>

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -122,7 +122,7 @@ Mensuelle"</string>
 <string name="feedback_show_only_one_or_show_all">"Afficher uniquement les derniers commentaires par rapport/établissement"</string>
 <string name="feedback_return">"Retour à toutes les enquêtes"</string>
 <string name="quality_of_care">"QUALITÉ DES SOINS (QoC) SCORE:"</string>
-<string name="overall_quality_of_care">"Note globale sur la qualité des soins (QoC):"</string>
+<string name="overall_quality_of_care">"QoC:"</string>
 <string name="feedback_info_passed">"Reussi"</string>
 <string name="feedback_info_failed">"Raté"</string>
 <string name="feedback_info_not_answered">"Non répondu"</string>

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -122,7 +122,7 @@ Mensuelle"</string>
 <string name="feedback_show_only_one_or_show_all">"Afficher uniquement les derniers commentaires par rapport/établissement"</string>
 <string name="feedback_return">"Retour à toutes les enquêtes"</string>
 <string name="quality_of_care">"QUALITÉ DES SOINS (QoC) SCORE:"</string>
-<string name="overall_quality_of_care">"QoC:"</string>
+<string name="overall_quality_of_care">"QoC"</string>
 <string name="feedback_info_passed">"Reussi"</string>
 <string name="feedback_info_failed">"Raté"</string>
 <string name="feedback_info_not_answered">"Non répondu"</string>

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -140,7 +140,7 @@
 <string name="feedback_show_only_one_or_show_all">"បង្ហាញតែមតិយោបល់ចុងក្រោយក្នុងមួយកម្មវិធី / PUll"</string>
 <string name="feedback_return">"ត្រឡប់ទៅការស្ទង់មតិទាំងអស់"</string>
 <string name="quality_of_care">"គុណភាពនៃការថែរក្សា (QoC) ពិន្ទុ:"</string>
-<string name="overall_quality_of_care">ពិន្ទុគុណភាពថែរក្សាសរុប (QoC): "</string>
+<string name="overall_quality_of_care">QoC:"</string>
 <string name="feedback_info_passed">"ហុច"</string>
 <string name="feedback_info_failed">"មិនជោគជ័យ"</string>
 <string name="feedback_info_not_answered">"NA"</string>

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -140,7 +140,7 @@
 <string name="feedback_show_only_one_or_show_all">"បង្ហាញតែមតិយោបល់ចុងក្រោយក្នុងមួយកម្មវិធី / PUll"</string>
 <string name="feedback_return">"ត្រឡប់ទៅការស្ទង់មតិទាំងអស់"</string>
 <string name="quality_of_care">"គុណភាពនៃការថែរក្សា (QoC) ពិន្ទុ:"</string>
-<string name="overall_quality_of_care">QoC:"</string>
+<string name="overall_quality_of_care">QoC"</string>
 <string name="feedback_info_passed">"ហុច"</string>
 <string name="feedback_info_failed">"មិនជោគជ័យ"</string>
 <string name="feedback_info_not_answered">"NA"</string>

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -239,7 +239,7 @@
 <string name="header_reschedule">"ວາງແຜນໃໝ່"</string>
 <string name="planing_due_date">"ວັນໝົດກຳນົດ"</string>
 <string name="feedback_show_only_one_or_show_all">"ສະແດງສະເພາະຄວາມເຫັນທີ່ກ່ຽວຂ້ອງ"</string>
-<string name="overall_quality_of_care">"QoC:"</string>
+<string name="overall_quality_of_care">"QoC"</string>
 <string name="action_button_text">"ແຜນການປະຕິບັດງານ"</string>
 <string name="plan_action_title">"ການສັງເກດການ &amp; ແຜນການປະຕິບັດງານ"</string>
 <string name="plan_action_today_date">"ສຳເລັດແລ້ວ: %s"</string>

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -239,7 +239,7 @@
 <string name="header_reschedule">"ວາງແຜນໃໝ່"</string>
 <string name="planing_due_date">"ວັນໝົດກຳນົດ"</string>
 <string name="feedback_show_only_one_or_show_all">"ສະແດງສະເພາະຄວາມເຫັນທີ່ກ່ຽວຂ້ອງ"</string>
-<string name="overall_quality_of_care">"ຄະແນນລວມຄຸນນະພາບຂອງການບໍລິການ"</string>
+<string name="overall_quality_of_care">"QoC:"</string>
 <string name="action_button_text">"ແຜນການປະຕິບັດງານ"</string>
 <string name="plan_action_title">"ການສັງເກດການ &amp; ແຜນການປະຕິບັດງານ"</string>
 <string name="plan_action_today_date">"ສຳເລັດແລ້ວ: %s"</string>

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -124,7 +124,7 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="feedback_show_only_media">"Mostrar apenas perguntas contendo vídeo / imagem"</string>
 <string name="feedback_return">"Qualidade de atendimento (com base na última pesquisa)"</string>
 <string name="quality_of_care">"QUALIDADE DA ASSISTÊNCIA (QoC) PONTUAÇÃO:"</string>
-<string name="overall_quality_of_care">"Pontuação Global Quality of Care (QoC):"</string>
+<string name="overall_quality_of_care">"QoC:"</string>
 <string name="feedback_info_passed">"Aprovado"</string>
 <string name="feedback_info_failed">"Suspenso"</string>
 <string name="feedback_info_not_answered">"Não respondeu"</string>

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -124,7 +124,7 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="feedback_show_only_media">"Mostrar apenas perguntas contendo vídeo / imagem"</string>
 <string name="feedback_return">"Qualidade de atendimento (com base na última pesquisa)"</string>
 <string name="quality_of_care">"QUALIDADE DA ASSISTÊNCIA (QoC) PONTUAÇÃO:"</string>
-<string name="overall_quality_of_care">"QoC:"</string>
+<string name="overall_quality_of_care">"QoC"</string>
 <string name="feedback_info_passed">"Aprovado"</string>
 <string name="feedback_info_failed">"Suspenso"</string>
 <string name="feedback_info_not_answered">"Não respondeu"</string>

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -125,7 +125,7 @@ evaluation"</string>
 <string name="feedback_show_only_one_or_show_all">"Show only last feedback"</string>
 <string name="feedback_return">"Return to all surveys"</string>
 <string name="quality_of_care">"QUALITY OF CARE (QoC) SCORE:"</string>
-<string name="overall_quality_of_care">"Overall Quality of Care (QoC) score:"</string>
+<string name="overall_quality_of_care">"QoC:"</string>
 <string name="feedback_info_passed">"Pass"</string>
 <string name="feedback_info_failed">"Fail"</string>
 <string name="feedback_info_not_answered">"Na"</string>

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -125,7 +125,7 @@ evaluation"</string>
 <string name="feedback_show_only_one_or_show_all">"Show only last feedback"</string>
 <string name="feedback_return">"Return to all surveys"</string>
 <string name="quality_of_care">"QUALITY OF CARE (QoC) SCORE:"</string>
-<string name="overall_quality_of_care">"QoC:"</string>
+<string name="overall_quality_of_care">"QoC"</string>
 <string name="feedback_info_passed">"Pass"</string>
 <string name="feedback_info_failed">"Fail"</string>
 <string name="feedback_info_not_answered">"Na"</string>

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
@@ -20,7 +20,6 @@
 package org.eyeseetea.malariacare.fragments;
 
 import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
@@ -40,7 +39,6 @@ import android.widget.ImageButton;
 import android.widget.RelativeLayout;
 
 import org.eyeseetea.malariacare.R;
-import org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.models.EventExtended;
 import org.eyeseetea.malariacare.data.database.model.CompositeScoreDB;
 import org.eyeseetea.malariacare.data.database.model.ObsActionPlanDB;
 import org.eyeseetea.malariacare.data.database.model.QuestionDB;
@@ -70,6 +68,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
     private ArrayAdapter<CharSequence> mSubActionsAdapter;
 
     private CustomTextView mTotalScoreTextView;
+    private CustomTextView mCompetencyTextView;
     private CustomTextView mOrgUnitTextView;
     private CustomTextView mNextDateTextView;
     private CustomTextView mCompletionDateTextView;
@@ -290,6 +289,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
     }
 
     private void initLayoutHeaders() {
+        mCompetencyTextView = mRootView.findViewById(R.id.feedback_competency);
         mTotalScoreTextView = mRootView.findViewById(R.id.feedback_total_score);
         mOrgUnitTextView = mRootView.findViewById(
                 R.id.org_unit);
@@ -369,9 +369,14 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
 
     @Override
     public void renderHeaderInfo(String orgUnitName, Float mainScore, String completionDate,
-            String nextDate) {
+            String nextDate,
+            CompetencyScoreClassification classification) {
 
         mOrgUnitTextView.setText(orgUnitName);
+
+        CompetencyUtils.setBackgroundByCompetency(mCompetencyTextView, classification);
+        CompetencyUtils.setTextColorByCompetency(mCompetencyTextView, classification);
+        CompetencyUtils.setTextByCompetency(mCompetencyTextView, classification);
 
         if (mainScore > 0f) {
             mTotalScoreTextView.setText(String.format("%.1f%%", mainScore));

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
@@ -134,7 +134,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
     }
 
     private void initEditTexts() {
-        mCustomProviderText = (CustomEditText) mRootView.findViewById(
+        mCustomProviderText = mRootView.findViewById(
                 R.id.plan_action_provider_text);
 
         mCustomProviderText.addTextChangedListener(new TextWatcher() {
@@ -154,7 +154,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
             }
         });
 
-        mCustomGapsEditText = (CustomEditText) mRootView.findViewById(
+        mCustomGapsEditText = mRootView.findViewById(
                 R.id.plan_action_gasp_edit_text);
         mCustomGapsEditText.addTextChangedListener(new TextWatcher() {
             @Override
@@ -173,7 +173,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
             }
         });
 
-        mCustomActionPlanEditText = (CustomEditText) mRootView.findViewById(
+        mCustomActionPlanEditText = mRootView.findViewById(
                 R.id.plan_action_action_plan_edit_text);
 
         mCustomActionPlanEditText.addTextChangedListener(new TextWatcher() {
@@ -192,7 +192,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
                 presenter.actionPlanChanged(editable.toString());
             }
         });
-        mCustomActionOtherEditText = (CustomEditText) mRootView.findViewById(
+        mCustomActionOtherEditText = mRootView.findViewById(
                 R.id.plan_action_others_edit_text);
 
         mCustomActionOtherEditText.addTextChangedListener(new TextWatcher() {
@@ -217,51 +217,32 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
         mGoBack = (ImageButton) mRootView.findViewById(
                 R.id.backToSentSurveys);
 
-        mGoBack.setOnClickListener(new View.OnClickListener() {
-                                       @Override
-                                       public void onClick(View v) {
-                                           getActivity().onBackPressed();
-                                       }
-                                   }
+        mGoBack.setOnClickListener(v -> getActivity().onBackPressed()
         );
     }
 
     private void initFAB() {
         initFabComplete(mRootView);
 
-        fabShare = (FloatingActionButton) mRootView.findViewById(R.id.fab_share);
+        fabShare = mRootView.findViewById(R.id.fab_share);
 
-        fabShare.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                presenter.shareObsActionPlan();
-            }
-        });
+        fabShare.setOnClickListener(view -> presenter.shareObsActionPlan());
     }
 
     private void initFabComplete(RelativeLayout llLayout) {
-        mFabComplete = (FloatingActionButton) llLayout.findViewById(R.id.fab_save);
+        mFabComplete = llLayout.findViewById(R.id.fab_save);
 
-        mFabComplete.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                new AlertDialog.Builder(getActivity())
-                        .setTitle(null)
-                        .setMessage(getActivity().getString(
-                                R.string.dialog_info_ask_for_completion_plan))
-                        .setPositiveButton(android.R.string.yes,
-                                new DialogInterface.OnClickListener() {
-                                    public void onClick(DialogInterface arg0, int arg1) {
-                                        presenter.completePlan();
-                                    }
-                                })
-                        .setNegativeButton(android.R.string.no, null).create().show();
-            }
-        });
+        mFabComplete.setOnClickListener(view -> new AlertDialog.Builder(getActivity())
+                .setTitle(null)
+                .setMessage(getActivity().getString(
+                        R.string.dialog_info_ask_for_completion_plan))
+                .setPositiveButton(android.R.string.yes,
+                        (arg0, arg1) -> presenter.completePlan())
+                .setNegativeButton(android.R.string.no, null).create().show());
     }
 
     private void initActions() {
-        actionSpinner = (CustomSpinner) mRootView.findViewById(R.id.plan_action_spinner);
+        actionSpinner = mRootView.findViewById(R.id.plan_action_spinner);
 
         mActionsAdapter =
                 new ArrayAdapter(mRootView.getContext(), android.R.layout.simple_spinner_item);
@@ -281,7 +262,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
     }
 
     private void initSubActions() {
-        secondaryActionSpinner = (CustomSpinner) mRootView.findViewById(
+        secondaryActionSpinner = mRootView.findViewById(
                 R.id.plan_action_secondary_spinner);
         secondaryView = mRootView.findViewById(R.id.secondaryView);
         otherView = mRootView.findViewById(R.id.otherView);
@@ -307,12 +288,12 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
     }
 
     private void initLayoutHeaders() {
-        mTotalScoreTextView = (CustomTextView) mRootView.findViewById(R.id.feedback_total_score);
-        mOrgUnitTextView = (CustomTextView) mRootView.findViewById(
+        mTotalScoreTextView = mRootView.findViewById(R.id.feedback_total_score);
+        mOrgUnitTextView = mRootView.findViewById(
                 R.id.org_unit);
-        mCompletionDateTextView = (CustomTextView) mRootView.findViewById(
+        mCompletionDateTextView = mRootView.findViewById(
                 R.id.completion_date);
-        mNextDateTextView = (CustomTextView) mRootView.findViewById(R.id.next_date);
+        mNextDateTextView = mRootView.findViewById(R.id.next_date);
     }
 
     @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
@@ -48,8 +48,10 @@ import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.Session;
 import org.eyeseetea.malariacare.data.database.utils.planning.SurveyPlanner;
+import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 import org.eyeseetea.malariacare.layout.utils.LayoutUtils;
 import org.eyeseetea.malariacare.presentation.presenters.ObsActionPlanPresenter;
+import org.eyeseetea.malariacare.utils.CompetencyUtils;
 import org.eyeseetea.malariacare.utils.Constants;
 import org.eyeseetea.malariacare.utils.DateParser;
 import org.eyeseetea.malariacare.views.CustomEditText;
@@ -360,7 +362,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
             mFabComplete.setImageResource(R.drawable.ic_action_uncheck);
         } else if (status == Constants.SURVEY_SENT) {
             mFabComplete.setImageResource(R.drawable.ic_double_check);
-        }else {
+        } else {
             mFabComplete.setImageResource(R.drawable.ic_action_check);
         }
     }
@@ -422,7 +424,8 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
     public void enableShareButton() {
         fabShare.setEnabled(true);
         fabShare.getBackground().clearColorFilter();
-        int shareColor = ContextCompat.getColor(fabShare.getContext(), R.color.share_fab_background);
+        int shareColor = ContextCompat.getColor(fabShare.getContext(),
+                R.color.share_fab_background);
 
         fabShare.getBackground().setColorFilter(shareColor, PorterDuff.Mode.SRC_IN);
 
@@ -446,6 +449,16 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
         data += getString(R.string.on) + " " + dateParser.format
                 (survey.getCompletionDate(), DateParser.EUROPEAN_DATE_FORMAT)
                 + "\n";
+
+
+        CompetencyScoreClassification classification =
+                CompetencyScoreClassification.get(
+                        survey.getCompetencyScoreClassification());
+
+        String competencyText = CompetencyUtils.getTextByCompetency(classification, getActivity());
+        data += getString(R.string.dashboard_title_planned_competency).toUpperCase() + ": "
+                + competencyText + "\n";
+
         int roundedScore = Math.round(survey.getMainScore());
         data += getString(R.string.quality_of_care) + " " + roundedScore + "% \n";
 
@@ -453,8 +466,9 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
                 dateParser.format(SurveyPlanner.getInstance().findScheduledDateBySurvey(survey),
                         DateParser.EUROPEAN_DATE_FORMAT));
 
-        if(obsActionPlan.getProvider()!=null && !obsActionPlan.getProvider().isEmpty()) {
-            data += "\n\n" + getString(R.string.plan_action_provider_title) + " " + obsActionPlan.getProvider();
+        if (obsActionPlan.getProvider() != null && !obsActionPlan.getProvider().isEmpty()) {
+            data += "\n\n" + getString(R.string.plan_action_provider_title) + " "
+                    + obsActionPlan.getProvider();
         }
 
         data += "\n\n" + getString(R.string.plan_action_gasp_title) + " ";

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
@@ -138,17 +138,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
         mCustomProviderText = mRootView.findViewById(
                 R.id.plan_action_provider_text);
 
-        mCustomProviderText.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
-            @Override
-            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
+        mCustomProviderText.addTextChangedListener(new CustomTextWatcher() {
             @Override
             public void afterTextChanged(Editable editable) {
                 presenter.providerChanged(editable.toString());
@@ -157,17 +147,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
 
         mCustomGapsEditText = mRootView.findViewById(
                 R.id.plan_action_gasp_edit_text);
-        mCustomGapsEditText.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
-            @Override
-            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
+        mCustomGapsEditText.addTextChangedListener(new CustomTextWatcher() {
             @Override
             public void afterTextChanged(Editable editable) {
                 presenter.gaspChanged(editable.toString());
@@ -177,17 +157,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
         mCustomActionPlanEditText = mRootView.findViewById(
                 R.id.plan_action_action_plan_edit_text);
 
-        mCustomActionPlanEditText.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
-            @Override
-            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
+        mCustomActionPlanEditText.addTextChangedListener(new CustomTextWatcher() {
             @Override
             public void afterTextChanged(Editable editable) {
                 presenter.actionPlanChanged(editable.toString());
@@ -196,17 +166,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
         mCustomActionOtherEditText = mRootView.findViewById(
                 R.id.plan_action_others_edit_text);
 
-        mCustomActionOtherEditText.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
-            @Override
-            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
+        mCustomActionOtherEditText.addTextChangedListener(new CustomTextWatcher() {
             @Override
             public void afterTextChanged(Editable editable) {
                 presenter.subActionOtherChanged(editable.toString());
@@ -536,4 +496,22 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
 
         System.out.println("data:" + data);
     }
+
+    class CustomTextWatcher implements TextWatcher {
+        @Override
+        public void beforeTextChanged (CharSequence charSequence,int i, int i1, int i2){
+
+        }
+
+        @Override
+        public void onTextChanged (CharSequence charSequence,int i, int i1, int i2){
+
+        }
+
+        @Override
+        public void afterTextChanged (Editable editable){
+        }
+    }
 }
+
+

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/ObsActionPlanPresenter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/ObsActionPlanPresenter.java
@@ -13,6 +13,7 @@ import org.eyeseetea.malariacare.data.database.model.ObsActionPlanDB;
 import org.eyeseetea.malariacare.data.database.model.QuestionDB;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.utils.planning.SurveyPlanner;
+import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 import org.eyeseetea.malariacare.observables.ObservablePush;
 import org.eyeseetea.malariacare.utils.DateParser;
 import org.eyeseetea.malariacare.utils.Constants;
@@ -71,8 +72,12 @@ public class ObsActionPlanPresenter {
                         DateParser.EUROPEAN_DATE_FORMAT);
             }
 
+            CompetencyScoreClassification classification =
+                    CompetencyScoreClassification.get(
+                            mSurvey.getCompetencyScoreClassification());
+
             mView.renderHeaderInfo(mSurvey.getOrgUnit().getName(), mSurvey.getMainScore(),
-                    formattedCompletionDate, formattedNextDate);
+                    formattedCompletionDate, formattedNextDate, classification);
         }
     }
 
@@ -293,7 +298,7 @@ public class ObsActionPlanPresenter {
         void renderBasicPlanInfo(String provider, String gasp, String actionPlan);
 
         void renderHeaderInfo(String orgUnitName, Float mainScore, String completionDate,
-                String nextDate);
+                String nextDate, CompetencyScoreClassification classification);
 
         void renderOtherSubAction(String action2);
 

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/CompetencyUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/CompetencyUtils.java
@@ -10,9 +10,9 @@ import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 
 public class CompetencyUtils {
-    public static void setTextByCompetency(
-            TextView textView, CompetencyScoreClassification classification) {
-        Context context = textView.getContext();
+    public static String getTextByCompetency(
+            CompetencyScoreClassification classification, Context context) {
+
         String competencyText = "";
 
         if (classification == CompetencyScoreClassification.NOT_AVAILABLE) {
@@ -27,6 +27,14 @@ public class CompetencyUtils {
             competencyText = context.getString(
                     R.string.competency_classification_not_competent);
         }
+
+        return competencyText;
+    }
+
+    public static void setTextByCompetency(
+            TextView textView, CompetencyScoreClassification classification) {
+
+        String competencyText = getTextByCompetency(classification, textView.getContext());
 
         textView.setText(competencyText);
     }

--- a/app/src/main/res/layout/plan_action_fragment.xml
+++ b/app/src/main/res/layout/plan_action_fragment.xml
@@ -41,7 +41,8 @@
                 android:layout_below="@id/org_unit"
                 android:orientation="horizontal"
                 android:background="@color/new_grey"
-                android:weightSum="2">
+                android:weightSum="2"
+                android:padding="8dp">
 
                 <org.eyeseetea.malariacare.views.CustomTextView
                     android:id="@+id/observations"
@@ -50,7 +51,6 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal|center_vertical"
                     android:gravity="center_horizontal|center_vertical"
-                    android:padding="5dp"
                     android:minHeight="@dimen/header_min_height"
                     android:text="@string/plan_action_title"
                     android:textColor="@color/new_grey_text_color"
@@ -67,8 +67,8 @@
 
                     <android.support.design.widget.FloatingActionButton
                         android:id="@+id/fab_save"
-                        android:layout_width="@dimen/standard_30"
-                        android:layout_height="@dimen/standard_30"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
                         android:background="@color/share_fab_background"
                         app:backgroundTint="@color/share_fab_background"
                         app:fabSize="mini"
@@ -78,8 +78,8 @@
 
                     <android.support.design.widget.FloatingActionButton
                         android:id="@+id/fab_share"
-                        android:layout_width="@dimen/standard_30"
-                        android:layout_height="@dimen/standard_30"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
                         android:background="@color/share_fab_background"
                         app:backgroundTint="@color/share_fab_background"
                         app:fabSize="mini"
@@ -94,25 +94,54 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/observations_title_container"
                 android:background="@color/clear_gray"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:layout_margin="8dp">
 
                 <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/margin_lateral_feedback_radiobutton"
                     android:orientation="horizontal">
 
                     <org.eyeseetea.malariacare.views.CustomTextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="left|center_vertical"
+                        android:gravity="left"
+                        android:text="@string/dashboard_title_planned_competency"
+                        android:textAppearance="?android:attr/textAppearanceLarge"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/xsmall_text_size"
+                        android:textStyle="bold"
+                        android:padding="4dp"
+                        app:tDimension="@string/font_size_level1"
+                        app:tFontName="@string/medium_font_name" />
 
+                    <org.eyeseetea.malariacare.views.CustomTextView
+                        android:id="@+id/feedback_competency"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="left|center_vertical"
+                        android:layout_marginLeft="4dp"
+                        android:gravity="center_horizontal"
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:textColor="@color/white"
+                        android:textSize="@dimen/xsmall_text_size"
+                        android:textStyle="bold"
+                        android:padding="4dp"
+                        app:tDimension="@string/font_size_level1"
+                        app:tFontName="@string/medium_font_name" />
+
+                    <org.eyeseetea.malariacare.views.CustomTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="left|center_vertical"
                         android:gravity="left"
                         android:text="@string/overall_quality_of_care"
                         android:textAppearance="?android:attr/textAppearanceLarge"
                         android:textColor="@color/black"
                         android:textSize="@dimen/xsmall_text_size"
                         android:textStyle="bold"
+                        android:layout_marginLeft="16dp"
                         app:tDimension="@string/font_size_level1"
                         app:tFontName="@string/medium_font_name" />
 
@@ -124,17 +153,17 @@
                         android:layout_marginLeft="4dp"
                         android:gravity="center_horizontal"
                         android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="@color/black"
+                        android:textColor="@color/white"
                         android:textSize="@dimen/xsmall_text_size"
                         android:textStyle="bold"
+                        android:padding="4dp"
                         app:tDimension="@string/font_size_level1"
                         app:tFontName="@string/medium_font_name" />
                 </LinearLayout>
 
                 <RelativeLayout
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/margin_lateral_feedback_radiobutton">
+                    android:layout_height="wrap_content">
 
                     <org.eyeseetea.malariacare.views.CustomTextView
                         android:id="@+id/completion_date"
@@ -146,6 +175,7 @@
                         android:textColor="@color/new_grey_text_color"
                         android:textSize="@dimen/xsmall_text_size"
                         android:textStyle="normal"
+                        android:padding="4dp"
                         app:tDimension="@string/font_size_level1"
                         app:tFontName="@string/font_name_regular" />
 
@@ -157,10 +187,11 @@
                         android:layout_marginRight="@dimen/margin_lateral_feedback_radiobutton"
                         android:layout_toRightOf="@+id/completion_date"
                         android:gravity="center_vertical"
-                        android:paddingLeft="10dp"
+                        android:paddingLeft="16dp"
                         android:singleLine="true"
                         android:textAppearance="?android:attr/textAppearanceSmall"
                         android:textColor="@color/new_grey_text_color"
+                        android:padding="4dp"
                         android:textSize="@dimen/xsmall_text_size"
                         app:tDimension="@string/font_size_level1"
                         app:tFontName="@string/font_name_regular" />

--- a/app/src/main/res/layout/plan_action_fragment.xml
+++ b/app/src/main/res/layout/plan_action_fragment.xml
@@ -126,7 +126,6 @@
                         android:textAppearance="?android:attr/textAppearanceSmall"
                         android:textColor="@color/white"
                         android:textSize="@dimen/xsmall_text_size"
-                        android:textStyle="bold"
                         android:padding="4dp"
                         app:tDimension="@string/font_size_level1"
                         app:tFontName="@string/medium_font_name" />
@@ -155,7 +154,6 @@
                         android:textAppearance="?android:attr/textAppearanceSmall"
                         android:textColor="@color/white"
                         android:textSize="@dimen/xsmall_text_size"
-                        android:textStyle="bold"
                         android:padding="4dp"
                         app:tDimension="@string/font_size_level1"
                         app:tFontName="@string/medium_font_name" />


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2262      
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature-show_new_score_classification_in_observations Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Show the new competency score classification in observations & and action plan

### :memo: How is it being implemented?

- I have modified Obs & Action plan layout and fragment to show competency and I have included competency text in the text to share.
- I have applied minor refactors, for example, apply java 8 lambdas and remove boilerplate code for TextWatchers

### :boom: How can it be tested?

 **Use case 1:** - After pull or execute from the previous version, all surveys on feedback should show Competency as not available and show it in theirs Obs & Action plans.

 **Use case 2:** - Create a new survey and complete all questions (critical and non-critical) then the feedback should show competency as Competent and show it in its Obs & Action plan.

 **Use case 3:** - Create a new survey and complete all non-critical but fail one critical question then the feedback should show competency as Not Competent and show it in its Obs & Action plan.

 **Use case 4:** - Create a new survey and complete all critical but fail several non-critical questions then the feedback should show competency as Comp. Improv.  and show it in its Obs & Action plan.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

![observations](https://user-images.githubusercontent.com/5593590/55712416-fc360d00-59ee-11e9-96e8-5bc7452f2ae9.png)
