### PR TITLE
Feature monitoring based on competency

### DIFF
--- a/app/src/hnqis/res/layout/planning_survey_row.xml
+++ b/app/src/hnqis/res/layout/planning_survey_row.xml
@@ -100,7 +100,7 @@
                 android:layout_gravity="center_vertical"
                 android:ellipsize="end"
                 android:lines="1"
-                android:text="@string/dashboard_title_planned_competency"
+                android:text="@string/competency_title"
                 android:textSize="@dimen/planing_text_size"
                 app:tDimension="@string/font_size_level1"
                 app:tFontName="@string/medium_font_name"/>

--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -116,7 +116,7 @@ clínica"</string>
 <string name="dashboard_title_planned_type_next_30">"Próximos 30 días"</string>
 <string name="dashboard_title_planned_type_future">"Futuro"</string>
 <string name="dashboard_title_planned_productivity">"Prd"</string>
-<string name="dashboard_title_planned_competency">"Competencia"</string>
+<string name="competency_title">"Competencia"</string>
 <string name="dashboard_title_planned_next_qa">"Próx. eval."</string>
 <string name="assessment_sent_competency">"Competencia"</string>
 <string name="feedback_show_only_failed">"Mostrar solo preguntas falladas"</string>

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -114,7 +114,7 @@ Mensuelle"</string>
 <string name="dashboard_title_planned_type_next_30">"30 prochains jours"</string>
 <string name="dashboard_title_planned_type_future">"Futurs"</string>
 <string name="dashboard_title_planned_productivity">"Prd"</string>
-<string name="dashboard_title_planned_competency">"Compétence"</string>
+<string name="competency_title">"Compétence"</string>
 <string name="dashboard_title_planned_next_qa">"Proch. éval."</string>
 <string name="assessment_sent_competency">"Compétence"</string>
 <string name="feedback_show_only_failed">"Afficher uniquement les questions ratées"</string>

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -132,7 +132,7 @@
 <string name="dashboard_title_planned_type_next_30">"30 ថ្ងៃបន្ទាប់"</string>
 <string name="dashboard_title_planned_type_future">"អនាគត"</string>
 <string name="dashboard_title_planned_productivity">"Prd"</string>
-<string name="dashboard_title_planned_competency">"សមត្ថកិច្ច"</string>
+<string name="competency_title">"សមត្ថកិច្ច"</string>
 <string name="dashboard_title_planned_next_qa">"QA បន្ទាប់"</string>
 <string name="assessment_sent_competency">"សមត្ថកិច្ច"</string>
 <string name="feedback_show_only_failed">"បង្ហាញតែសំណួរដែលបរាជ័យ"</string>

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -130,7 +130,7 @@
 <string name="dashboard_title_planned_type_next_30">"ໃນ 30 ວັນຕໍ່ໜ້າ"</string>
 <string name="dashboard_title_planned_type_future">"ຄັ້ງຕໍ່ໄປ"</string>
 <string name="dashboard_title_planned_productivity">"ຈຳນວນ"</string>
-<string name="dashboard_title_planned_competency">"ຄວາມສາມາດ"</string>
+<string name="competency_title">"ຄວາມສາມາດ"</string>
 <string name="dashboard_title_planned_next_qa">"ການປະເມີນຄຸນນະພາບຄັ້ງຕໍ່ໄປ"</string>
 <string name="assessment_sent_competency">"ຄວາມສາມາດ"</string>
 <string name="feedback_show_only_failed">"ສະແດງສະເພາະຄຳຖາມທີ່ຕອບຜິດ"</string>

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -117,7 +117,7 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="dashboard_title_planned_type_next_30">"Próximos 30 dias"</string>
 <string name="dashboard_title_planned_type_future">"Futuro"</string>
 <string name="dashboard_title_planned_productivity">"Prd"</string>
-<string name="dashboard_title_planned_competency">"Competência"</string>
+<string name="competency_title">"Competência"</string>
 <string name="dashboard_title_planned_next_qa">"Próx. aval."</string>
 <string name="assessment_sent_competency">"Competência"</string>
 <string name="feedback_show_only_failed">"Mostrar só falhou perguntas"</string>

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -304,4 +304,9 @@ evaluation"</string>
 <string name="competency_classification_competent">Competent</string>
 <string name="competency_classification_competent_improvement">Comp. Improv.</string>
 <string name="competency_classification_not_competent">Not Competent</string>
+
+<string name="competency_classification_not_available_abbreviation">NA</string>
+<string name="competency_classification_competent_abbreviation">C</string>
+<string name="competency_classification_competent_improvement_abbreviation">CI</string>
+<string name="competency_classification_not_competent_abbreviation">NC</string>
 </resources>

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -117,7 +117,7 @@ evaluation"</string>
 <string name="dashboard_title_planned_type_next_30">"Next 30 days"</string>
 <string name="dashboard_title_planned_type_future">"Future"</string>
 <string name="dashboard_title_planned_productivity">"Prd"</string>
-<string name="dashboard_title_planned_competency">"Competency"</string>
+<string name="competency_title">"Competency"</string>
 <string name="dashboard_title_planned_next_qa">"Next QA"</string>
 <string name="assessment_sent_competency">"Competency"</string>
 <string name="feedback_show_only_failed">"Show only failed questions"</string>

--- a/app/src/main/assets/dashboard/dashboard.html
+++ b/app/src/main/assets/dashboard/dashboard.html
@@ -235,6 +235,5 @@
 <div  id="multipleEventLegend" style="display:none"><span class="line-title"></span></div>
 
 <span class="line-no-surveys" id="noSurveysText"></span>
-<script type = "text/javascript" src="mockData.js"> </script>
 </body>
 </html>

--- a/app/src/main/assets/dashboard/dashboard.html
+++ b/app/src/main/assets/dashboard/dashboard.html
@@ -18,8 +18,8 @@
   -->
 <html xmlns="http://www.w3.org/1999/html">
 <head>
-    <meta name = "viewport" content = "width=device-width, initial-scale=1.0, user-scalable=no">
-    <script type = "text/javascript" src="Chart.min.js"> </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <script type="text/javascript" src="Chart.min.js"></script>
     <style>
         select{
             -webkit-appearance: none;
@@ -126,22 +126,22 @@
         td.red{
             background-color: #fa8900;
         }
-        td.greencircle>div{
-            margin: auto;
-            border-radius: 50%;
-            height: 100%;
-            color: white;
-            font-weight: bold;
-            margin-top: 5px;
-            padding: 3px;
-            margin-bottom: 5px;
-        }
         .centerspan{
             margin: auto;
             text-align: center;
             align-content: center;
         }
-        td.ambercircle>div{
+        td.competent-circle>div{
+            margin: auto;
+            border-radius: 50%;
+            height: 100%;
+            color: black;
+            font-weight: bold;
+            margin-top: 5px;
+            padding: 3px;
+            margin-bottom: 5px;
+        }
+        td.competent_improvement-circle>div{
             margin: auto;
             border-radius: 50%;
             height: 100%;
@@ -151,7 +151,7 @@
             padding: 3px;
             margin-bottom: 5px;
         }
-        td.redcircle>div{
+        td.not-competent-circle>div{
             margin: auto;
             border-radius: 50%;
             height: 100%;
@@ -161,6 +161,18 @@
             padding: 3px;
             margin-bottom: 5px;
         }
+        td.not_available-circle>div{
+            margin: auto;
+            border-radius: 50%;
+            height: 100%;
+            color: black;
+            font-weight: bold;
+            margin-top: 5px;
+            padding: 3px;
+            margin-bottom: 5px;
+            border: 1px solid black;
+        }
+
         .hide {
             display:none;
         }
@@ -176,6 +188,7 @@
             width: 98.5%!important;
             font-size: 40px!important;
         }
+
     </style>
 </head>
 <body>
@@ -194,24 +207,26 @@
 
 <!--Table 12 months-->
 
-<script type = "text/javascript" src="translated.messages.js"> </script>
+<script type="text/javascript" src="translated.messages.js"></script>
 
-<script type = "text/javascript" src="html.nodes.modifications.js"> </script>
+<script type="text/javascript" src="html.nodes.modifications.js"></script>
 
-<script type = "text/javascript" src="controller.js"> </script>
+<script type="text/javascript" src="controller.js"></script>
 
-<script type = "text/javascript" src="sent.month.js"> </script>
+<script type="text/javascript" src="sent.month.js"></script>
 
-<script type = "text/javascript" src="pie.tabgroup.js"> </script>
+<script type="text/javascript" src="pie.tabgroup.js"></script>
 
-<script type = "text/javascript" src="table.facilities.js"> </script>
+<script type="text/javascript" src="table.facilities.js"></script>
 
 <!-- pie template with table-->
-<script type = "text/html" id="pieTemplate">
+<script type="text/html" id="pieTemplate">
     <div id="graphicCanvas">
         <div style="display:inline;">
-            <canvas id="tabgroupCanvas###" style="width: 60%; height: auto; left:0px; display:block;"></canvas>
-            <div id="tabgroupLegend###" class="chart-legend" style="display:block;right: 0px;position: absolute;top: 10%; padding-right:20%;">
+            <canvas id="tabgroupCanvas###"
+                    style="width: 60%; height: auto; left:0px; display:block;"></canvas>
+            <div id="tabgroupLegend###" class="chart-legend"
+                 style="display:block;right: 0px;position: absolute;top: 10%; padding-right:20%;">
                 <span id="tabgroupTip###" class="tip" style="display:none;"></span>
             </div>
         </div>
@@ -232,7 +247,7 @@
         </div>
     </div>
 </script>
-<div  id="multipleEventLegend" style="display:none"><span class="line-title"></span></div>
+<div id="multipleEventLegend" style="display:none"><span class="line-title"></span></div>
 
 <span class="line-no-surveys" id="noSurveysText"></span>
 </body>

--- a/app/src/main/assets/dashboard/dashboard.html
+++ b/app/src/main/assets/dashboard/dashboard.html
@@ -140,6 +140,7 @@
             margin-top: 5px;
             padding: 3px;
             margin-bottom: 5px;
+            border: 1px solid white;
         }
         td.competent_improvement-circle>div{
             margin: auto;
@@ -150,6 +151,7 @@
             margin-top: 5px;
             padding: 3px;
             margin-bottom: 5px;
+            border: 1px solid white;
         }
         td.not-competent-circle>div{
             margin: auto;
@@ -160,17 +162,18 @@
             margin-top: 5px;
             padding: 3px;
             margin-bottom: 5px;
+            border: 1px solid white;
         }
         td.not_available-circle>div{
             margin: auto;
             border-radius: 50%;
             height: 100%;
-            color: black;
+            color: white;
             font-weight: bold;
             margin-top: 5px;
             padding: 3px;
             margin-bottom: 5px;
-            border: 1px solid black;
+            border: 1px solid white;
         }
 
         .hide {

--- a/app/src/main/assets/dashboard/pie.tabgroup.js
+++ b/app/src/main/assets/dashboard/pie.tabgroup.js
@@ -17,41 +17,28 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         valueC:0
     })
 */
-var green;
-var yellow;
-var red;
-var high;
-var medium;
-var low;
-var mediumPieFormatted;
+var competentColor;
+var competentImprovementColor;
+var notCompetentColor;
+var competentText;
+var competentImprovementText;
+var notCompetentText;
 
 function setClassification(classification){
-    high=classification["high"];
-    medium=classification["medium"];
-    low=classification["low"];
-    mediumPieFormatted=classification["mediumFormatted"];
+    competentText=classification["competentText"];
+    competentImprovementText=classification["competentImprovementText"];
+    notCompetentText=classification["notCompetentText"];
 }
-function setGreen(color){
-    green=color["color"];
-    //console.log(green);
-}
-function setGreen(color){
-    green=color["color"];
-    //console.log(green);
-}
-function setGreen(color){
-    green=color["color"];
-    //console.log(green);
+function setCompetentColor(color){
+    competentColor=color["color"];
 }
 
-function setYellow(color){
-    yellow=color["color"];
-    //console.log(yellow);
+function setCompetentImprovementColor(color){
+    competentImprovementColor=color["color"];
 }
 
-function setRed(color){
-    red=color["color"];
-    //console.log(red);
+function setNotCompetentColor(color){
+    notCompetentColor=color["color"];
 }
 
 function pieXTabGroupChart(data){
@@ -60,25 +47,22 @@ function pieXTabGroupChart(data){
     var legendDOMId="tabgroupLegend"+data.idTabGroup;
     var titleDOMId="tabgroupTitle"+data.idTabGroup;
     var titleTableDOMId="tabgroupTip"+data.idTabGroup;
-    //console.log(green);
-    //console.log(yellow);
-    //console.log(red);
 
     //Chart
     var ctx = document.getElementById(canvasDOMId).getContext("2d");
     var  myChart  = new Chart(ctx).Pie(
                                [{
                                    value: data.valueA,
-                                   color: green,
-                                   label: "A (>"+high+")"
+                                   color: competentColor,
+                                   label: "A (>"+competentText+")"
                                }, {
                                    value: data.valueB,
-                                   color: yellow,
-                                   label: "B ("+mediumPieFormatted+")"
+                                   color: competentImprovementColor,
+                                   label: "B ("+competentImprovementText +")"
                                }, {
                                    value: data.valueC,
-                                   color: red,
-                                   label: "C (<"+low+")"
+                                   color: notCompetentColor,
+                                   label: "C (<"+notCompetentText+")"
                                }],
                                {
                                    tooltipTemplate: "<%= value %>",

--- a/app/src/main/assets/dashboard/pie.tabgroup.js
+++ b/app/src/main/assets/dashboard/pie.tabgroup.js
@@ -78,6 +78,10 @@ function pieXTabGroupChart(data){
                                    value: data.valueC,
                                    color: notCompetentColor,
                                    label: "C ("+notCompetentText+")"
+                               }, {
+                                   value: data.valueNA,
+                                   color: notAvailableColor,
+                                   label: ""+notAvailableText+""
                                }],
                                {
                                    tooltipTemplate: "<%= value %>",

--- a/app/src/main/assets/dashboard/pie.tabgroup.js
+++ b/app/src/main/assets/dashboard/pie.tabgroup.js
@@ -20,14 +20,25 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 var competentColor;
 var competentImprovementColor;
 var notCompetentColor;
+var notAvailableColor;
 var competentText;
 var competentImprovementText;
 var notCompetentText;
+var notAvailableText;
+var competentAbbreviationText;
+var competentImprovementAbbreviationText;
+var notCompetentAbbreviationText;
+var notAvailableAbbreviationText;
 
 function setClassification(classification){
     competentText=classification["competentText"];
     competentImprovementText=classification["competentImprovementText"];
     notCompetentText=classification["notCompetentText"];
+    notAvailableText=classification["notAvailableText"];
+    competentAbbreviationText=classification["competentAbbreviationText"];
+    competentImprovementAbbreviationText=classification["competentImprovementAbbreviationText"];
+    notCompetentAbbreviationText=classification["notCompetentAbbreviationText"];
+    notAvailableAbbreviationText=classification["notAvailableAbbreviationText"];
 }
 function setCompetentColor(color){
     competentColor=color["color"];
@@ -39,6 +50,10 @@ function setCompetentImprovementColor(color){
 
 function setNotCompetentColor(color){
     notCompetentColor=color["color"];
+}
+
+function setNotAvailableColor(color){
+    notAvailableColor=color["color"];
 }
 
 function pieXTabGroupChart(data){
@@ -54,7 +69,7 @@ function pieXTabGroupChart(data){
                                [{
                                    value: data.valueA,
                                    color: competentColor,
-                                   label: "A (>"+competentText+")"
+                                   label: "A ("+competentText+")"
                                }, {
                                    value: data.valueB,
                                    color: competentImprovementColor,
@@ -62,7 +77,7 @@ function pieXTabGroupChart(data){
                                }, {
                                    value: data.valueC,
                                    color: notCompetentColor,
-                                   label: "C (<"+notCompetentText+")"
+                                   label: "C ("+notCompetentText+")"
                                }],
                                {
                                    tooltipTemplate: "<%= value %>",

--- a/app/src/main/assets/dashboard/table.facilities.js
+++ b/app/src/main/assets/dashboard/table.facilities.js
@@ -10,16 +10,16 @@
 						values:[
 							null,
 							null,
-							[{"uid":31,"score":0.0},{"uid":30,"score":100.0}],
+							[{"uid":31,"competency":3},{"uid":30,"competency":3}],
 							null,
-							[{"uid":1,"score":0.0},{"uid":12,"score":100.0},{"uid":21,"score":100.0}],
-							null,
-							null,
+							[{"uid":1,"competency":2},{"uid":12,"competency":100.0},{"uid":21,"competency":0}],
 							null,
 							null,
 							null,
 							null,
-							[{"uid":113,"score":10.0}]
+							null,
+							null,
+							[{"uid":113,"competency":1}]
 						]
 					},
 					...
@@ -30,6 +30,14 @@
 */
 var inputDataTablesPerProgram=[];
 var inputDataTablesPerOrgUnit=[];
+
+const competencyScoreClassification = {
+    NOT_AVAILABLE: 0,
+    COMPETENT: 1,
+    COMPETENT_NEEDS_IMPROVEMENT: 2,
+    NOT_COMPETENT: 3
+}
+
 //Save the table data
 function buildTablesPerProgram(tabGroupId,dataFacilities){
 	inputDataTablesPerProgram.push(dataFacilities);
@@ -126,23 +134,20 @@ function buildRowFacility(facility){
 	    //value x month
 	    for(var i=0;i<facility.values.length;i++){
 	    	var facilityMonth=facility.values[i];
-	    	var average=0;
+	    	var competency=0;
 	    	var asterisk = "";
 	    	if(facilityMonth==null){
-	    		var average=null;
+	    		competency=null;
 	    	}else{
-	    		for(var d=0;d<facilityMonth.length;d++){
-	    			average+= facilityMonth[d].score;
-	    		}
-	    		average=average/facilityMonth.length;
-	    		average=Math.round(average);
+	    	    competency = facilityMonth[0].competency;
+
                 if(facilityMonth.length>1){
                     showMultipleEventLegend();
                     asterisk = "*";
                 }
 	    	}
 
-            row=row+""+buildColorXScore(average,facilityMonth)+""+buildCellXScore(average)+"</span></div>"+asterisk+"</td>";
+            row=row+""+buildColorXScore(competency,facilityMonth)+""+buildCellXScore(competency)+"</span></div>"+asterisk+"</td>";
 	    }
 	}
 	//end row
@@ -151,34 +156,50 @@ function buildRowFacility(facility){
 }
 
 function buildColorXScore(value, listOfSurveys){
-	if(value==null){
-		return "<td class='novisible' ><div class='circlerow' ><span class='centerspan'>";
-	}
-	if(value<low){
-	    if(listOfSurveys.length>1){
-		    return "<td class='redcircle'   onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\"><div class='circlerow' style='background-color:"+red+"'><span class='centerspan'>";
-		}else{
-		    return "<td class='redcircle'   onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\"><div class='circlerow' style='background-color:"+red+"'><span class='centerspan'>";
-		}
-	}else if(value<medium){
-	    if(listOfSurveys.length>1){
-		    return "<td class='ambercircle'  onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\"><div class='circlerow' style='background-color:"+yellow+"'><span class='centerspan'>";
-		}else{
-		    return "<td class='ambercircle'  onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\"><div class='circlerow' style='background-color:"+yellow+"'><span class='centerspan'>";
-		}
-	} else{
+    if(value==null){
+        return "<td class='novisible' ><div class='circlerow' ><span class='centerspan'>";
+    }
+    if(value == competencyScoreClassification.COMPETENT){
         if(listOfSurveys.length>1){
-            return "<td class='greencircle'  onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\" ><div class='circlerow' style='background-color:"+green+"'><span class='centerspan'>";
+            return "<td class='competent-circle' onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\" ><div class='circlerow' style='background-color:"+competentColor+";border: 1px solid "+competentColor+";'><span class='centerspan'>";
         }else{
-            return "<td class='greencircle'  onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\" ><div class='circlerow' style='background-color:"+green+"'><span class='centerspan'>";
+            return "<td class='competent-circle' onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\" ><div class='circlerow' style='background-color:"+competentColor+";border: 1px solid "+competentColor+";'><span class='centerspan'>";
         }
-	}
+    } else if(value == competencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT){
+        if(listOfSurveys.length>1){
+            return "<td class='competent_improvement-circle' onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\"><div class='circlerow' style='background-color:"+competentImprovementColor+";border: 1px solid "+competentImprovementColor+";'><span class='centerspan'>";
+        }else{
+            return "<td class='competent_improvement-circle' onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\"><div class='circlerow' style='background-color:"+competentImprovementColor+";border: 1px solid "+competentImprovementColor+";'><span class='centerspan'>";
+        }
+    } else if(value == competencyScoreClassification.NOT_COMPETENT){
+        if(listOfSurveys.length>1){
+            return "<td class='not-competent-circle' onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\"><div class='circlerow' style='background-color:"+notCompetentColor+";border: 1px solid "+notCompetentColor+";'><span class='centerspan'>";
+        }else{
+            return "<td class='not-competent-circle' onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\"><div class='circlerow' style='background-color:"+notCompetentColor+";border: 1px solid "+notCompetentColor+";'><span class='centerspan'>";
+        }
+    } else {
+        //NOT_AVAILABLE
+        if(listOfSurveys.length>1){
+            return "<td class='not_available-circle' onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\"><div class='circlerow' style='background-color:"+notAvailableColor+"'><span class='centerspan'>";
+        }else{
+            return "<td class='not_available-circle' onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\"><div class='circlerow' style='background-color:"+notAvailableColor+"'><span class='centerspan'>";
+        }
+    }
 }
 
-function buildCellXScore(value){
-	if(value==null){
+function buildCellXScore(competency){
+	if(competency==null){
 		return '';
-	}
+	} else if(competency == competencyScoreClassification.COMPETENT){
+        return competentAbbreviationText;
+    } else if(competency == competencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT){
+        return competentImprovementAbbreviationText;
+    } else if(competency == competencyScoreClassification.NOT_COMPETENT){
+        return notCompetentAbbreviationText;
+    } else {
+        return notAvailableAbbreviationText;
+    }
+
 	return value;
 }
 

--- a/app/src/main/assets/dashboard/table.facilities.js
+++ b/app/src/main/assets/dashboard/table.facilities.js
@@ -161,19 +161,19 @@ function buildColorXScore(value, listOfSurveys){
     }
     if(value == competencyScoreClassification.COMPETENT){
         if(listOfSurveys.length>1){
-            return "<td class='competent-circle' onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\" ><div class='circlerow' style='background-color:"+competentColor+";border: 1px solid "+competentColor+";'><span class='centerspan'>";
+            return "<td class='competent-circle' onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\" ><div class='circlerow' style='background-color:"+competentColor+"'><span class='centerspan'>";
         }else{
-            return "<td class='competent-circle' onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\" ><div class='circlerow' style='background-color:"+competentColor+";border: 1px solid "+competentColor+";'><span class='centerspan'>";
+            return "<td class='competent-circle' onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\" ><div class='circlerow' style='background-color:"+competentColor+"'><span class='centerspan'>";
         }
     } else if(value == competencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT){
         if(listOfSurveys.length>1){
-            return "<td class='competent_improvement-circle' onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\"><div class='circlerow' style='background-color:"+competentImprovementColor+";border: 1px solid "+competentImprovementColor+";'><span class='centerspan'>";
+            return "<td class='competent_improvement-circle' onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\"><div class='circlerow' style='background-color:"+competentImprovementColor+"'><span class='centerspan'>";
         }else{
-            return "<td class='competent_improvement-circle' onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\"><div class='circlerow' style='background-color:"+competentImprovementColor+";border: 1px solid "+competentImprovementColor+";'><span class='centerspan'>";
+            return "<td class='competent_improvement-circle' onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\"><div class='circlerow' style='background-color:"+competentImprovementColor+"'><span class='centerspan'>";
         }
     } else if(value == competencyScoreClassification.NOT_COMPETENT){
         if(listOfSurveys.length>1){
-            return "<td class='not-competent-circle' onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\"><div class='circlerow' style='background-color:"+notCompetentColor+";border: 1px solid "+notCompetentColor+";'><span class='centerspan'>";
+            return "<td class='not-competent-circle' onclick=\"androidPassUids(\'" +getListOfUids(listOfSurveys)+ "\')\"><div class='circlerow' style='background-color:"+notCompetentColor+"'><span class='centerspan'>";
         }else{
             return "<td class='not-competent-circle' onclick=\"androidMoveToFeedback(\'" +listOfSurveys[0].id+ "\')\"><div class='circlerow' style='background-color:"+notCompetentColor+";border: 1px solid "+notCompetentColor+";'><span class='centerspan'>";
         }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/facilities/FacilityColumnData.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/facilities/FacilityColumnData.java
@@ -52,7 +52,7 @@ public class FacilityColumnData {
         }
         String jsonObject="[";
         for(SurveyDB survey:surveys){
-            jsonObject+="{\"id\":"+survey.getId_survey() + ",\"score\":" +  survey.getMainScore()+"},";
+            jsonObject+="{\"id\":"+survey.getId_survey() + ",\"competency\":" +  survey.getCompetencyScoreClassification()+"},";
         }
         jsonObject=jsonObject.substring(0,jsonObject.lastIndexOf(","));
         jsonObject= jsonObject +"]";

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/facilities/FacilityTableBuilderBase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/facilities/FacilityTableBuilderBase.java
@@ -44,6 +44,8 @@ public class FacilityTableBuilderBase {
             "javascript:setCompetentImprovementColor(%s)";
     public static final String JAVASCRIPT_SET_NOT_COMPETENT_COLOR =
             "javascript:setNotCompetentColor(%s)";
+    public static final String JAVASCRIPT_SET_NOT_AVAILABLE_COLOR =
+            "javascript:setNotAvailableColor(%s)";
     public static final String JAVASCRIPT_SET_CLASSIFICATION = "javascript:setClassification(%s)";
 
     /**
@@ -81,6 +83,12 @@ public class FacilityTableBuilderBase {
                 "{color:'" + getHtmlCodeColor(color) + "'}");
         Log.d(TAG, injectColor);
         webView.loadUrl(injectColor);
+        color = context.getResources().getString(R.color.competency_not_available_background_color);
+        injectColor = String.format(
+                JAVASCRIPT_SET_NOT_AVAILABLE_COLOR,
+                "{color:'" + getHtmlCodeColor(color) + "'}");
+        Log.d(TAG, injectColor);
+        webView.loadUrl(injectColor);
 
         String injectClassification = String.format(JAVASCRIPT_SET_CLASSIFICATION,
                 "{competentText:'" + CompetencyUtils.getTextByCompetency(
@@ -88,15 +96,29 @@ public class FacilityTableBuilderBase {
                         "competentImprovementText:'" + CompetencyUtils.getTextByCompetency(
                         CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT, context) + "'," +
                         "notCompetentText:'" + CompetencyUtils.getTextByCompetency(
-                        CompetencyScoreClassification.NOT_COMPETENT, context) + "'}");
+                        CompetencyScoreClassification.NOT_COMPETENT, context)+ "'," +
+                        "notAvailableText:'" + CompetencyUtils.getTextByCompetency(
+                        CompetencyScoreClassification.NOT_AVAILABLE, context)+ "'," +
+                        "competentAbbreviationText:'" + CompetencyUtils.getAbbreviationTextByCompetency(
+                CompetencyScoreClassification.COMPETENT, context) + "'," +
+                        "competentImprovementAbbreviationText:'" + CompetencyUtils.getAbbreviationTextByCompetency(
+                        CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT, context) + "'," +
+                        "notCompetentAbbreviationText:'" + CompetencyUtils.getAbbreviationTextByCompetency(
+                        CompetencyScoreClassification.NOT_COMPETENT, context) + "'," +
+                        "notAvailableAbbreviationText:'" + CompetencyUtils.getAbbreviationTextByCompetency(
+                            CompetencyScoreClassification.NOT_AVAILABLE, context) + "'}");
 
         Log.d(TAG, injectClassification);
         webView.loadUrl(injectClassification);
     }
 
     private static String getHtmlCodeColor(String color) {
-        //remove the first two characters(about alpha color).
-        String colorRRGGBB = "#" + color.substring(3, 9);
-        return colorRRGGBB;
+        try{
+            //remove the first two characters(about alpha color).
+            String colorRRGGBB = "#" + color.substring(3, 9);
+            return colorRRGGBB;
+        } catch (Exception e){
+            return "";
+        }
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/facilities/FacilityTableBuilderBase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/facilities/FacilityTableBuilderBase.java
@@ -26,7 +26,9 @@ import android.webkit.WebView;
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
+import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 import org.eyeseetea.malariacare.domain.entity.ScoreType;
+import org.eyeseetea.malariacare.utils.CompetencyUtils;
 
 import java.util.List;
 
@@ -36,10 +38,12 @@ import java.util.List;
  */
 public class FacilityTableBuilderBase {
 
-    private static final String TAG=".FacilityTableBuilder";
-    public static final String JAVASCRIPT_SET_GREEN = "javascript:setGreen(%s)";
-    public static final String JAVASCRIPT_SET_YELLOW = "javascript:setYellow(%s)";
-    public static final String JAVASCRIPT_SET_RED = "javascript:setRed(%s)";
+    private static final String TAG = ".FacilityTableBuilder";
+    public static final String JAVASCRIPT_SET_COMPETENT_COLOR = "javascript:setCompetentColor(%s)";
+    public static final String JAVASCRIPT_SET_COMPETENT_IMPROVEMENT_COLOR =
+            "javascript:setCompetentImprovementColor(%s)";
+    public static final String JAVASCRIPT_SET_NOT_COMPETENT_COLOR =
+            "javascript:setNotCompetentColor(%s)";
     public static final String JAVASCRIPT_SET_CLASSIFICATION = "javascript:setClassification(%s)";
 
     /**
@@ -48,41 +52,51 @@ public class FacilityTableBuilderBase {
     List<SurveyDB> surveys;
 
 
-
     /**
      * Default constructor
      */
     public FacilityTableBuilderBase(List<SurveyDB> surveys) {
         this.surveys = surveys;
     }
-    public static void setColor(WebView webView){
-        //noinspection ResourceType
-        String color=PreferencesState.getInstance().getContext().getResources().getString(R.color.high_score_color);
-        String injectColor=String.format(JAVASCRIPT_SET_GREEN,"{color:'"+getHtmlCodeColor(color)+"'}");
-        Log.d(TAG, injectColor);
-        webView.loadUrl(injectColor);
-        //noinspection ResourceType
-        color=PreferencesState.getInstance().getContext().getResources().getString(R.color.low_score_color);
-        injectColor=String.format(JAVASCRIPT_SET_RED,"{color:'"+getHtmlCodeColor(color)+"'}");
-        Log.d(TAG, injectColor);
-        webView.loadUrl(injectColor);
-        //noinspection ResourceType
-        color=PreferencesState.getInstance().getContext().getResources().getString(R.color.medium_score_color);
-        injectColor = String.format(JAVASCRIPT_SET_YELLOW,"{color:'"+getHtmlCodeColor(color)+"'}");
-        Log.d(TAG,injectColor);
-        webView.loadUrl(injectColor);
-        String injectClassification = String.format(JAVASCRIPT_SET_CLASSIFICATION,"{high:'"+ScoreType.getMonitoringMinimalHigh()+"'," +
-                "medium:'"+ScoreType.getMonitoringMaximumMedium()+"'," +
-                "mediumFormatted:'"+ScoreType.getMonitoringMediumPieFormat()+"'," +
-                "low:'"+ScoreType.getMonitoringMaximumLow()+"'}");
-        Log.d(TAG,injectClassification);
-        webView.loadUrl(injectClassification);
 
+    public static void setColor(WebView webView) {
+        Context context = PreferencesState.getInstance().getContext();
+
+        //noinspection ResourceType
+        String color = context.getResources().getString(R.color.competency_competent_background_color);
+        String injectColor = String.format(
+                JAVASCRIPT_SET_COMPETENT_COLOR, "{color:'" + getHtmlCodeColor(color) + "'}");
+        Log.d(TAG, injectColor);
+        webView.loadUrl(injectColor);
+        //noinspection ResourceType
+        color = context.getResources().getString(R.color.competency_not_competent_background_color);
+        injectColor = String.format(
+                JAVASCRIPT_SET_NOT_COMPETENT_COLOR, "{color:'" + getHtmlCodeColor(color) + "'}");
+        Log.d(TAG, injectColor);
+        webView.loadUrl(injectColor);
+        //noinspection ResourceType
+        color = context.getResources().getString(R.color.competency_competent_improvement_background_color);
+        injectColor = String.format(
+                JAVASCRIPT_SET_COMPETENT_IMPROVEMENT_COLOR,
+                "{color:'" + getHtmlCodeColor(color) + "'}");
+        Log.d(TAG, injectColor);
+        webView.loadUrl(injectColor);
+
+        String injectClassification = String.format(JAVASCRIPT_SET_CLASSIFICATION,
+                "{competentText:'" + CompetencyUtils.getTextByCompetency(
+                        CompetencyScoreClassification.COMPETENT, context) + "'," +
+                        "competentImprovementText:'" + CompetencyUtils.getTextByCompetency(
+                        CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT, context) + "'," +
+                        "notCompetentText:'" + CompetencyUtils.getTextByCompetency(
+                        CompetencyScoreClassification.NOT_COMPETENT, context) + "'}");
+
+        Log.d(TAG, injectClassification);
+        webView.loadUrl(injectClassification);
     }
 
     private static String getHtmlCodeColor(String color) {
         //remove the first two characters(about alpha color).
-        String colorRRGGBB="#"+color.substring(3,9);
+        String colorRRGGBB = "#" + color.substring(3, 9);
         return colorRRGGBB;
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/facilities/FacilityTableBuilderByProgram.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/facilities/FacilityTableBuilderByProgram.java
@@ -80,7 +80,7 @@ public class FacilityTableBuilderByProgram extends  FacilityTableBuilderBase {
         for(Map.Entry<String,FacilityTableDataByProgram> tableEntry:facilityTableDataMap.entrySet()){
             String cadena=tableEntry.getKey();
             FacilityTableDataByProgram facilityTableData=tableEntry.getValue();
-            inyectDataInChart(webView, cadena, facilityTableData.getAsJSON());
+            injectDataInChart(webView, cadena, facilityTableData.getAsJSON());
         }
 
     }
@@ -90,7 +90,7 @@ public class FacilityTableBuilderByProgram extends  FacilityTableBuilderBase {
         webView.loadUrl(String.format(JAVASCRIPT_SHOW));
     }
 
-    void inyectDataInChart(WebView webView, String id, String json) {
+    void injectDataInChart(WebView webView, String id, String json) {
         //Inyect in browser
         String updateChartJS=String.format(JAVASCRIPT_UPDATE_TABLE,id,json);
         Log.d(TAG, updateChartJS);

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/pies/PieBuilderByOrgUnit.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/pies/PieBuilderByOrgUnit.java
@@ -75,7 +75,7 @@ public class PieBuilderByOrgUnit extends PieBuilderBase {
             pieTabGroupDataMap.put(orgUnit, pieTabGroupData);
         }
         //Increment surveys for that month
-        pieTabGroupData.incCounter(survey.getMainScore());
+        pieTabGroupData.incCounter(survey.getCompetencyScoreClassification());
     }
 
 

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/pies/PieBuilderByProgram.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/pies/PieBuilderByProgram.java
@@ -76,7 +76,7 @@ public class PieBuilderByProgram extends PieBuilderBase {
             pieTabGroupDataMap.put(program, pieTabGroupData);
         }
         //Increment surveys for that month
-        pieTabGroupData.incCounter(survey.getMainScore());
+        pieTabGroupData.incCounter(survey.getCompetencyScoreClassification());
     }
     private List<PieDataByProgram> build(List<SurveyDB> surveys) {
         for(SurveyDB survey:surveys){

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/pies/PieDataBase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/pies/PieDataBase.java
@@ -19,51 +19,37 @@
 
 package org.eyeseetea.malariacare.data.database.utils.monitor.pies;
 
+import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 import org.eyeseetea.malariacare.domain.entity.ScoreType;
 import org.eyeseetea.malariacare.utils.Constants;
 
-/**
- * VO thats hold the info of a single pie chart
- * Created by arrizabalaga on 9/10/15.
- */
 public class PieDataBase {
 
-    static final String JSONFORMAT="{title:'%s',tip:'%s',idTabGroup: %d,valueA:%d,valueB:%d,valueC:%d,uidprogram:'%s',uidorgunit:'%s'}";
+    static final String JSONFORMAT =
+            "{title:'%s',tip:'%s',idTabGroup: %d,valueA:%d,valueB:%d,valueC:%d,valueNA:%d,uidprogram:'%s',"
+                    + "uidorgunit:'%s'}";
 
-    /**
-     * Number of surveys with A score
-     */
     int numA;
-    /**
-     * Number of surveys with B score
-     */
+
     int numB;
-    /**
-     * Number of surveys with C score
-     */
+
     int numC;
 
+    int numNA;
 
-    /**
-     * Increments the right counter according to the score
-     * @param score
-     */
-    public void incCounter(float score){
-        ScoreType scoreType = new ScoreType(score);
-        if(scoreType.getClassification() == ScoreType.Classification.LOW){
-            numC++;
-            return;
-        }
 
-        else if(scoreType.getClassification() == ScoreType.Classification.MEDIUM){
+    public void incCounter(int competencyScoreClassification) {
+        CompetencyScoreClassification classification =
+                CompetencyScoreClassification.get(competencyScoreClassification);
+
+        if (classification == CompetencyScoreClassification.COMPETENT) {
+            numA++;
+        } else if (classification == CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT) {
             numB++;
-            return;
+        } else if (classification == CompetencyScoreClassification.NOT_COMPETENT) {
+            numC++;
+        } else {
+            numNA++;
         }
-
-        numA++;
-        return;
     }
-
-
-
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/pies/PieDataByOrgUnit.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/pies/PieDataByOrgUnit.java
@@ -41,7 +41,7 @@ public class PieDataByOrgUnit extends PieDataBase {
     }
     public String toJSON(String tipChat){
         String pieTitle = String.format("%s (%s)", AUtils.escapeQuotes(orgUnit.getName()), orgUnit.getId_org_unit());
-        String json = String.format(JSONFORMAT, pieTitle, tipChat, orgUnit.getId_org_unit(), this.numA, this.numB, this.numC, orgUnit.getUid(), orgUnit.getUid());
+        String json = String.format(JSONFORMAT, pieTitle, tipChat, orgUnit.getId_org_unit(), this.numA, this.numB, this.numC, this.numNA, orgUnit.getUid(), orgUnit.getUid());
         return json;
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/pies/PieDataByProgram.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/monitor/pies/PieDataByProgram.java
@@ -40,7 +40,7 @@ public class PieDataByProgram extends PieDataBase {
     }
     public String toJSON(String tipChat){
         String pieTitle = String.format("%s (%s)", AUtils.escapeQuotes(program.getName()), AUtils.escapeQuotes(program.getName()));
-        String json = String.format(JSONFORMAT, pieTitle, tipChat, program.getId_program(), this.numA, this.numB, this.numC, program.getUid(), program.getUid());
+        String json = String.format(JSONFORMAT, pieTitle, tipChat, program.getId_program(), this.numA, this.numB, this.numC,this.numNA, program.getUid(), program.getUid());
         return json;
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorFragment.java
@@ -59,18 +59,18 @@ import org.eyeseetea.malariacare.data.database.utils.monitor.facilities.Facility
 import org.eyeseetea.malariacare.data.database.utils.monitor.pies.PieBuilderByOrgUnit;
 import org.eyeseetea.malariacare.data.database.utils.monitor.pies.PieBuilderByProgram;
 import org.eyeseetea.malariacare.data.database.utils.services.BaseServiceBundle;
+import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 import org.eyeseetea.malariacare.domain.entity.ScoreType;
 import org.eyeseetea.malariacare.layout.dashboard.config.MonitorFilter;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.services.SurveyService;
-import org.eyeseetea.malariacare.utils.AUtils;
+import org.eyeseetea.malariacare.utils.CompetencyUtils;
 import org.eyeseetea.malariacare.utils.DateParser;
 import org.eyeseetea.malariacare.views.filters.OrgUnitProgramFilterView;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 
 public class MonitorFragment extends Fragment implements IModuleFragment {
     List<SurveyDB> surveysForGraphic;
@@ -407,28 +407,38 @@ public class MonitorFragment extends Fragment implements IModuleFragment {
         orgUnit.setText(surveys.get(0).getOrgUnit().getName());
         Button cancel = (Button) v.findViewById(R.id.cancel);
         LinearLayout linearLayout = (LinearLayout) v.findViewById(R.id.log_content);
-        View row = inflater.inflate(R.layout.item_list_dialog_header, null);
-        ((TextView)row.findViewById(R.id.first_column)).setText(R.string.assessment_sent_date);
-        ((TextView)row.findViewById(R.id.second_column)).setText(R.string.score);
+
+        View row = inflater.inflate(R.layout.content_survey_list_header_monitoring, null);
+
         linearLayout.addView(row);
         final AlertDialog alertDialog = builder.create();
         for(final SurveyDB survey: surveys){
-            row = inflater.inflate(R.layout.item_list_row_row, null);
-            TextView completionDate = (TextView) row.findViewById(R.id.first_column);
-            TextView score = (TextView) row.findViewById(R.id.second_column);
+            row = inflater.inflate(R.layout.item_survey_monitoring, null);
+            TextView completionDateView = row.findViewById(R.id.survey_completion_date_item_view);
+            TextView competencyView = row.findViewById(R.id.survey_competency_item_view);
+            TextView scoreView = row.findViewById(R.id.survey_score_item_view);
             DateParser dateParser = new DateParser();
-            completionDate.setText(dateParser.getEuropeanFormattedDate(survey.getCompletionDate()));
-            score.setText(Math.round(survey.getMainScore())+"");
+            completionDateView.setText(dateParser.getEuropeanFormattedDate(survey.getCompletionDate()));
+            scoreView.setText(Math.round(survey.getMainScore())+"");
             Resources resources = PreferencesState.getInstance().getContext().getResources();
 
             ScoreType scoreType = new ScoreType(survey.getMainScore());
             if (scoreType.isTypeA()) {
-                score.setBackgroundColor(resources.getColor(R.color.high_score_color));
+                scoreView.setBackgroundColor(resources.getColor(R.color.high_score_color));
             }else if (scoreType.isTypeB()){
-                score.setBackgroundColor(resources.getColor(R.color.medium_score_color));
+                scoreView.setBackgroundColor(resources.getColor(R.color.medium_score_color));
             }else if (scoreType.isTypeC()){
-                score.setBackgroundColor(resources.getColor(R.color.low_score_color));
+                scoreView.setBackgroundColor(resources.getColor(R.color.low_score_color));
             }
+
+            CompetencyScoreClassification classification =
+                    CompetencyScoreClassification.get(
+                            survey.getCompetencyScoreClassification());
+
+            CompetencyUtils.setBackgroundByCompetency(competencyView, classification);
+            CompetencyUtils.setTextByCompetency(competencyView, classification);
+            CompetencyUtils.setTextColorByCompetency(competencyView, classification);
+
             row.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorFragment.java
@@ -34,11 +34,14 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.eyeseetea.malariacare.DashboardActivity;
 import org.eyeseetea.malariacare.R;
@@ -339,6 +342,12 @@ public class MonitorFragment extends Fragment implements IModuleFragment {
                 }else{
                     FacilityTableBuilderByProgram.showFacilities(view);
                 }
+            }
+
+            @Override
+            public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error){
+                //Your code to do
+                Toast.makeText(getActivity(), "Your Internet Connection May not be active Or " + error , Toast.LENGTH_LONG).show();
             }
         });
         //Load html

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/PlanActionFragment.java
@@ -421,7 +421,7 @@ public class PlanActionFragment extends Fragment implements IModuleFragment,
                         survey.getCompetencyScoreClassification());
 
         String competencyText = CompetencyUtils.getTextByCompetency(classification, getActivity());
-        data += getString(R.string.dashboard_title_planned_competency).toUpperCase() + ": "
+        data += getString(R.string.competency_title).toUpperCase() + ": "
                 + competencyText + "\n";
 
         int roundedScore = Math.round(survey.getMainScore());

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/CompetencyUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/CompetencyUtils.java
@@ -31,6 +31,29 @@ public class CompetencyUtils {
         return competencyText;
     }
 
+    public static String getAbbreviationTextByCompetency(
+            CompetencyScoreClassification classification, Context context) {
+
+        String competencyText = "";
+
+        if (classification == CompetencyScoreClassification.NOT_AVAILABLE) {
+            competencyText = context.getString(
+                    R.string.competency_classification_not_available_abbreviation);
+        } else if (classification == CompetencyScoreClassification.COMPETENT) {
+            competencyText = context.getString(
+                    R.string.competency_classification_competent_abbreviation);
+        } else if (classification == CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT) {
+            competencyText = context.getString(
+                    R.string.competency_classification_competent_improvement_abbreviation);
+        } else if (classification == CompetencyScoreClassification.NOT_COMPETENT) {
+            competencyText = context.getString(
+                    R.string.competency_classification_not_competent_abbreviation);
+        }
+
+        return competencyText;
+    }
+
+
     public static int getColorByCompetency(
             CompetencyScoreClassification classification, Context context) {
 

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/CompetencyUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/CompetencyUtils.java
@@ -88,16 +88,7 @@ public class CompetencyUtils {
 
         Context context = textView.getContext();
 
-        if (classification == CompetencyScoreClassification.NOT_AVAILABLE) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                textView.setBackground(context.getDrawable(R.drawable.background_black_border));
-            } else {
-                textView.setBackgroundDrawable(
-                        ContextCompat.getDrawable(context, R.drawable.background_black_border));
-            }
-        } else {
-            textView.setBackgroundColor(getColorByCompetency(classification, context));
-        }
+        textView.setBackgroundColor(getColorByCompetency(classification, context));
     }
 
     public static void setTextColorByCompetency(TextView textView,

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/CompetencyUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/CompetencyUtils.java
@@ -31,6 +31,27 @@ public class CompetencyUtils {
         return competencyText;
     }
 
+    public static int getColorByCompetency(
+            CompetencyScoreClassification classification, Context context) {
+
+        int color;
+
+        if (classification == CompetencyScoreClassification.COMPETENT) {
+            color = ContextCompat.getColor(context, R.color.competency_competent_background_color);
+        } else if (classification == CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT) {
+            color = ContextCompat.getColor(context,
+                    R.color.competency_competent_improvement_background_color);
+        } else if (classification == CompetencyScoreClassification.NOT_COMPETENT) {
+            color = ContextCompat.getColor(context,
+                    R.color.competency_not_competent_background_color);
+        } else {
+            color = ContextCompat.getColor(context,
+                    R.color.competency_not_available_background_color);
+        }
+
+        return color;
+    }
+
     public static void setTextByCompetency(
             TextView textView, CompetencyScoreClassification classification) {
 
@@ -44,22 +65,15 @@ public class CompetencyUtils {
 
         Context context = textView.getContext();
 
-        if (classification == CompetencyScoreClassification.COMPETENT) {
-            textView.setBackgroundColor(
-                    ContextCompat.getColor(context, R.color.competency_competent_background_color));
-        } else if (classification == CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT) {
-            textView.setBackgroundColor(ContextCompat.getColor(context,
-                    R.color.competency_competent_improvement_background_color));
-        } else if (classification == CompetencyScoreClassification.NOT_COMPETENT) {
-            textView.setBackgroundColor(ContextCompat.getColor(context,
-                    R.color.competency_not_competent_background_color));
-        } else {
+        if (classification == CompetencyScoreClassification.NOT_AVAILABLE) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 textView.setBackground(context.getDrawable(R.drawable.background_black_border));
             } else {
                 textView.setBackgroundDrawable(
                         ContextCompat.getDrawable(context, R.drawable.background_black_border));
             }
+        } else {
+            textView.setBackgroundColor(getColorByCompetency(classification, context));
         }
     }
 

--- a/app/src/main/res/drawable/background_black_border.xml
+++ b/app/src/main/res/drawable/background_black_border.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
-    <solid android:color="@color/competency_not_available_background_color" />
-    <stroke android:width="1dip" android:color="@color/black"/>
-</shape>

--- a/app/src/main/res/layout/content_survey_list_header_monitoring.xml
+++ b/app/src/main/res/layout/content_survey_list_header_monitoring.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1px"
+        android:background="@color/darkGrey" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/plan_grey_light"
+        android:orientation="horizontal">
+
+        <org.eyeseetea.sdk.presentation.views.CustomTextView
+            android:id="@+id/survey_completion_date_header_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.33"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:ellipsize="end"
+            android:lines="1"
+            android:padding="10dp"
+            android:text="@string/assessment_sent_date"
+            android:textColor="@color/darkGrey"
+            android:textSize="16dp"
+            android:textStyle="bold"
+            app:font_name="@string/font_name_medium"
+            app:tDimension="@string/font_size_level4" />
+
+        <org.eyeseetea.sdk.presentation.views.CustomTextView
+            android:id="@+id/survey_competency_header_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.33"
+            android:layout_gravity="center"
+            android:background="@color/white"
+            android:gravity="center"
+            android:ellipsize="end"
+            android:lines="1"
+            android:padding="10dp"
+            android:text="@string/competency_title"
+            android:textColor="@color/darkGrey"
+            android:textSize="16dp"
+            android:textStyle="bold"
+            android:layout_margin="1dp"
+            app:font_name="@string/font_name_medium"
+            app:tDimension="@string/font_size_level4" />
+
+        <org.eyeseetea.sdk.presentation.views.CustomTextView
+            android:id="@+id/survey_score_header_view"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="0.33"
+            android:layout_gravity="center"
+            android:background="@color/white"
+            android:gravity="center"
+            android:padding="10dp"
+            android:text="@string/score"
+            android:ellipsize="end"
+            android:lines="1"
+            android:textColor="@color/darkGrey"
+            android:textSize="16dp"
+            android:textStyle="bold"
+            android:layout_margin="1dp"
+            app:font_name="@string/font_name_medium"
+            app:tDimension="@string/font_size_level4" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/item_survey_monitoring.xml
+++ b/app/src/main/res/layout/item_survey_monitoring.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <View
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="1px"
+        android:background="@color/darkGrey" />
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/plan_grey_light"
+        android:orientation="horizontal">
+    <org.eyeseetea.sdk.presentation.views.CustomTextView
+        android:id="@+id/survey_completion_date_item_view"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:background="@color/white"
+        android:layout_weight="0.33"
+        android:textColor="@color/darkGrey"
+        android:ellipsize="end"
+        android:lines="1"
+        android:textSize="16dp"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:textStyle="bold"
+        app:font_name="@string/font_name_medium"
+        app:tDimension="@string/font_size_level4" />
+
+        <org.eyeseetea.sdk.presentation.views.CustomTextView
+            android:id="@+id/survey_competency_item_view"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:background="@color/white"
+            android:layout_weight="0.33"
+            android:textColor="@color/darkGrey"
+            android:ellipsize="end"
+            android:lines="1"
+            android:textSize="16dp"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:textStyle="bold"
+            app:font_name="@string/font_name_medium"
+            app:tDimension="@string/font_size_level4" />
+
+
+        <org.eyeseetea.sdk.presentation.views.CustomTextView
+        android:id="@+id/survey_score_item_view"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="0.33"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:textColor="@color/white"
+        android:ellipsize="end"
+        android:lines="1"
+        android:textSize="16dp"
+        android:textStyle="bold"
+        app:font_name="@string/font_name_medium"
+        app:tDimension="@string/font_size_level4" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/plan_action_fragment.xml
+++ b/app/src/main/res/layout/plan_action_fragment.xml
@@ -107,7 +107,7 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="left|center_vertical"
                         android:gravity="left"
-                        android:text="@string/dashboard_title_planned_competency"
+                        android:text="@string/competency_title"
                         android:textAppearance="?android:attr/textAppearanceLarge"
                         android:textColor="@color/black"
                         android:textSize="@dimen/xsmall_text_size"

--- a/app/src/main/res/layout/planning_survey_row.xml
+++ b/app/src/main/res/layout/planning_survey_row.xml
@@ -100,7 +100,7 @@
                 android:layout_gravity="center_vertical"
                 android:ellipsize="end"
                 android:lines="1"
-                android:text="@string/dashboard_title_planned_competency"
+                android:text="@string/competency_title"
                 android:textSize="@dimen/planing_text_size"
                 app:tDimension="@string/font_size_level1"
                 app:tFontName="@string/medium_font_name"/>

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -81,10 +81,10 @@
     <color name="competency_competent_background_color">#FFFFFF</color>
     <color name="competency_competent_improvement_background_color">#78909c</color>
     <color name="competency_not_competent_background_color">#283747</color>
-    <color name="competency_not_available_background_color">@android:color/transparent</color>
+    <color name="competency_not_available_background_color">#A0A0A0</color>
 
     <color name="competency_competent_text_color">@color/black</color>
     <color name="competency_competent_improvement_text_color">@color/white</color>
     <color name="competency_not_competent_text_color">@color/white</color>
-    <color name="competency_not_available_text_color">@color/black</color>
+    <color name="competency_not_available_text_color">@color/white</color>
 </resources>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2264      
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature-monitoring_based_on_competency Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Modify monitoring to show graphs and bubbles based on competencies and show competency column also in the dialog that appears when clicking on the bubble that represents several surveys.

### :memo: How is it being implemented?

- I have created a new layout for dialog to add a new column because the layout was shared between surveys monitoring dialog and schedule plan history dialog.
- I have refactored the code to show competency column in dialog.
- I have refactored HTML file, javascript files to render monitor chart and bubbles according to competency.
- I have applied som refactors at the end: Create separate Dialogfragment with recycler view to render surveys in dialog.

- I have created a new issue to realize in the future about more refactors:  https://github.com/EyeSeeTea/malariapp/issues/2267

### :boom: How can it be tested?

 **Use case 1:** - In the monitoring the bubbles and pie chart should render according to competency

 **Use case 2:** - If you click on a bubble with an asterisk then a surveys dialog appears and should have competency column

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

![monitoring](https://user-images.githubusercontent.com/5593590/56031615-518c5a00-5d20-11e9-8ee1-d9ea087c6b4a.png)
![monitoring_surveys_dialog](https://user-images.githubusercontent.com/5593590/56031625-551fe100-5d20-11e9-993d-18c570d643c2.png)
