### PR TITLE
Feature eliminate gaps section from observation

### DIFF
--- a/app/src/eyeseetea/res/values-es/strings.xml
+++ b/app/src/eyeseetea/res/values-es/strings.xml
@@ -236,7 +236,6 @@ clínica"</string>
 <string name="plan_action_today_date">Terminado: %s</string>
 <string name="plan_action_next_date">Próxima: %s</string>
 <string name="plan_action_description">Describa lo que se observó durante la visita de un plan de acción específico para abordar las lagunas. Obsérvese también una mejora respecto a la brecha identificada durante la última visita</string>
-<string name="plan_action_gasp_title">Gaps:</string>
 <string name="plan_action_action_plan_title">Plan de acción:</string>
 <string name="plan_action_action_title">Acción:</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/eyeseetea/res/values-fr/strings.xml
+++ b/app/src/eyeseetea/res/values-fr/strings.xml
@@ -227,7 +227,6 @@ Mensuelle"</string>
 <string name="plan_action_today_date">"Terminé: %s"</string>
 <string name="plan_action_next_date">"Suivante: %s"</string>
 <string name="plan_action_description">"Décrivez ce qui a été observé lors de la visite d'un plan d'action spécifique pour combler les lacunes. Notez également une amélioration par rapport à un écart identifié lors de la dernière visite"</string>
-<string name="plan_action_gasp_title">Problèmes:</string>
 <string name="plan_action_action_plan_title">"Plan d'action:"</string>
 <string name="plan_action_action_title">Action:</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/eyeseetea/res/values-km/strings.xml
+++ b/app/src/eyeseetea/res/values-km/strings.xml
@@ -242,7 +242,6 @@ evaluation"</string>
 <string name="plan_action_today_date">បានបញ្ចប់: %s</string>
 <string name="plan_action_next_date">បន្ទាប់: %s</string>
 <string name="plan_action_description">រៀបរាប់ពីអ្វីដែលបានគេសង្កេតឃើញក្នុងអំឡុងពេលដំណើរទស្សនកិច្ចផែនការសកម្មភាពជាក់លាក់មួយសម្រាប់ការដោះស្រាយគម្លាតនេះ។ ចំណាំផងដែរប្រសើរជាងគម្លាតកំណត់អត្តសញ្ញាណក្នុងអំឡុងដំណើរទស្សនកិច្ចចុងក្រោយនេះជាមួយ</string>
-<string name="plan_action_gasp_title">Gaps:</string>
 <string name="plan_action_action_plan_title">ផែនការសកម្មភាព:</string>
 <string name="plan_action_action_title">សកម្មភាព:</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/eyeseetea/res/values-lo/strings.xml
+++ b/app/src/eyeseetea/res/values-lo/strings.xml
@@ -243,7 +243,6 @@
 <string name="plan_action_today_date">ແລ້ວສິ້ນ: %s</string>
 <string name="plan_action_next_date">ຕໍ່ໄປ: %s</string>
 <string name="plan_action_description">ອະທິບາຍສິ່ງທີ່ໄດ້ສັງເກດເຫັນໃນໄລຍະການຢ້ຽມຢາມເປັນແຜນການດໍາເນີນການສະເພາະໃດຫນຶ່ງສໍາລັບການແກ້ໄຂຊ່ອງຫວ່າງ. ຍັງໄດ້ສັງເກດການການປັບປຸງໃນໄລຍະຊ່ອງຫວ່າງລະບຸໃນໄລຍະຢ້ຽມຢາມທີ່ຜ່ານມາ</string>
-<string name="plan_action_gasp_title">Gaps:</string>
 <string name="plan_action_action_plan_title">ແຜນປະຕິບັດງານ:</string>
 <string name="plan_action_action_title">ການປະຕິບັດ:</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/eyeseetea/res/values-pt/strings.xml
+++ b/app/src/eyeseetea/res/values-pt/strings.xml
@@ -232,7 +232,6 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="plan_action_today_date">Concluído: %s</string>
 <string name="plan_action_next_date">Próxima: %s</string>
 <string name="plan_action_description">Descreva o que foi observado durante a visita um plano de ação específico para abordar lacunas. Observe também uma melhoria em relação a uma lacuna identificada durante a última visita</string>
-<string name="plan_action_gasp_title">Gaps:</string>
 <string name="plan_action_action_plan_title">Plano de ação:</string>
 <string name="plan_action_action_title">Açao:</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/eyeseetea/res/values/strings.xml
+++ b/app/src/eyeseetea/res/values/strings.xml
@@ -233,7 +233,6 @@ evaluation"</string>
 <string name="plan_action_today_date">Completed: %s</string>
 <string name="plan_action_next_date">Next: %s</string>
 <string name="plan_action_description">Describe what was observed during the visit a specific action plan for addressing gaps. Also note an improvement over a gap identified during the last visit</string>
-<string name="plan_action_gasp_title">Gaps:</string>
 <string name="plan_action_action_plan_title">Action plan:</string>
 <string name="plan_action_action_title">Action:</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -238,7 +238,6 @@ clínica"</string>
 <string name="plan_action_today_date">Terminado: %s</string>
 <string name="plan_action_next_date">Próxima: %s</string>
 <string name="plan_action_description">Describa lo que se observó durante la visita de un plan de acción específico para abordar las lagunas. Obsérvese también una mejora respecto a la brecha identificada durante la última visita</string>
-<string name="plan_action_gasp_title">BRECHAS:</string>
 <string name="plan_action_action_plan_title">PLAN DE ACCIÓN:</string>
 <string name="plan_action_action_title">ACCIÓN:</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -228,7 +228,6 @@ Mensuelle"</string>
 <string name="plan_action_today_date">"Terminé: %s"</string>
 <string name="plan_action_next_date">Prochaine: %s</string>
 <string name="plan_action_description">"Décrivez ce qui a été observé lors de la visite d'un plan d'action spécifique pour combler les lacunes. Notez également une amélioration par rapport à un écart identifié lors de la dernière visite"</string>
-<string name="plan_action_gasp_title">PROBLÈMES:</string>
 <string name="plan_action_action_plan_title">PLAN D\'ACTION:</string>
 <string name="plan_action_action_title">ACTION:</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -246,7 +246,6 @@
 <string name="plan_action_today_date">បានបញ្ចប់: %s</string>
 <string name="plan_action_next_date">ការវាយតម្លៃក្រោយ: %s</string>
 <string name="plan_action_description">រៀបរាប់ពីអ្វីដែលបានគេសង្កេតឃើញក្នុងអំឡុងពេលដំណើរទស្សនកិច្ចផែនការសកម្មភាពជាក់លាក់មួយសម្រាប់ការដោះស្រាយគម្លាតនេះ។ ចំណាំផងដែរប្រសើរជាងគម្លាតកំណត់អត្តសញ្ញាណក្នុងអំឡុងដំណើរទស្សនកិច្ចចុងក្រោយនេះជាមួយ</string>
-<string name="plan_action_gasp_title">គម្លាត:</string>
 <string name="plan_action_action_plan_title">ផែនការសកម្មភាព:</string>
 <string name="plan_action_action_title">សកម្មភាព:</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -245,7 +245,6 @@
 <string name="plan_action_today_date">"ສຳເລັດແລ້ວ: %s"</string>
 <string name="plan_action_next_date">ການປະເມີນຕໍ່ໄປນີ້: %s</string>
 <string name="plan_action_description">"ບັນຍາຍສິ່ງທີ່ໄດ້ສັງເກດເຫັນໃນລະຫວ່າງການລົງຍຽມຍາມລະບຸແຜນການແກ້ໄຂຊ່ອງວ່າງຕ່າງໆ. ພ້ອມທັງບັນທຶກການປັບປຸງຂໍ້ບົກຜ່ອງທີ່ພົບເຫັນໃນການລົງຍຽມຍາມຄັ້ງທີ່ຜ່ານມາ."</string>
-<string name="plan_action_gasp_title">"ຊ່ອງວ່າງ"</string>
 <string name="plan_action_action_plan_title">"ແຜນການປະຕິບັດງານ"</string>
 <string name="plan_action_action_title">"ການປະຕິບັດງານ"</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -234,7 +234,6 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="plan_action_today_date">Concluído: %s</string>
 <string name="plan_action_next_date">Próxima: %s</string>
 <string name="plan_action_description">Descreva o que foi observado durante a visita um plano de ação específico para abordar lacunas. Observe também uma melhoria em relação a uma lacuna identificada durante a última visita</string>
-<string name="plan_action_gasp_title">LACUNAS:</string>
 <string name="plan_action_action_plan_title">PLANO DE AÇÃO:</string>
 <string name="plan_action_action_title">AÇAO:</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -234,7 +234,6 @@ evaluation"</string>
 <string name="plan_action_today_date">Completed: %s</string>
 <string name="plan_action_next_date">Next: %s</string>
 <string name="plan_action_description">Describe what was observed during the visit a specific action plan for addressing gaps. Also note an improvement over a gap identified during the last visit</string>
-<string name="plan_action_gasp_title">GAPS:</string>
 <string name="plan_action_action_plan_title">ACTION PLAN:</string>
 <string name="plan_action_action_title">ACTION:</string>
 <string-array name="plan_action_dropdown_options">

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
@@ -307,7 +307,7 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
     }
 
     @Override
-    public void renderBasicObservations(String provider, String gasp, String actionPlan) {
+    public void renderBasicObservations(String provider, String actionPlan) {
         mCustomProviderText.setText(provider);
         mCustomActionPlanEditText.setText(actionPlan);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
@@ -87,7 +87,6 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
     private View otherView;
     private View secondaryView;
     private ImageButton mGoBack;
-    private CustomEditText mCustomGapsEditText;
     private CustomEditText mCustomProviderText;
     private CustomEditText mCustomActionPlanEditText;
     private CustomEditText mCustomActionOtherEditText;
@@ -112,8 +111,6 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
     public void onCreate(Bundle savedInstanceState) {
         Log.d(TAG, "onCreate");
         super.onCreate(savedInstanceState);
-        /*List<Feedback> feedbackList = new ArrayList<>();
-        Session.putServiceValue(PREPARE_FEEDBACK_ACTION_ITEMS, feedbackList);*/
     }
 
     @Override
@@ -178,15 +175,6 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
             @Override
             public void afterTextChanged(Editable editable) {
                 presenter.providerChanged(editable.toString());
-            }
-        });
-
-        mCustomGapsEditText = mRootView.findViewById(
-                R.id.plan_action_gasp_edit_text);
-        mCustomGapsEditText.addTextChangedListener(new CustomTextWatcher() {
-            @Override
-            public void afterTextChanged(Editable editable) {
-                presenter.gaspChanged(editable.toString());
             }
         });
 
@@ -311,7 +299,6 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
     @Override
     public void changeToReadOnlyMode() {
         mCustomProviderText.setEnabled(false);
-        mCustomGapsEditText.setEnabled(false);
         mCustomActionPlanEditText.setEnabled(false);
         mCustomActionOtherEditText.setEnabled(false);
         actionSpinner.setEnabled(false);
@@ -322,7 +309,6 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
     @Override
     public void renderBasicObservations(String provider, String gasp, String actionPlan) {
         mCustomProviderText.setText(provider);
-        mCustomGapsEditText.setText(gasp);
         mCustomActionPlanEditText.setText(actionPlan);
     }
 
@@ -470,11 +456,6 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
                     + observationViewModel.getProvider();
         }
 
-        data += "\n\n" + getString(R.string.plan_action_gasp_title) + " ";
-
-        if (observationViewModel.getGaps() != null && !observationViewModel.getGaps().isEmpty()) {
-            data += observationViewModel.getGaps();
-        }
 
         data += "\n" + getString(R.string.plan_action_action_plan_title) + " ";
 

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
@@ -116,7 +116,7 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
-        mRootView = (RelativeLayout) inflater.inflate(R.layout.plan_action_fragment, container,
+        mRootView = (RelativeLayout) inflater.inflate(R.layout.fragment_observations, container,
                 false);
 
         String surveyUid = getArguments().getString(SURVEY_UID);

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/mapper/ObservationMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/mapper/ObservationMapper.java
@@ -13,7 +13,6 @@ public class ObservationMapper {
     public static ObservationViewModel mapToViewModel(Observation observation,
             ServerMetadata serverMetadata) {
         String provider = "";
-        String gaps = "";
         String planAction = "";
         String action1 = "";
         String action2 = "";
@@ -25,9 +24,6 @@ public class ObservationMapper {
             if (observationValue.getObservationValueUid().equals(
                     serverMetadata.getProvider().getUId()) && observationValue.getValue() != null) {
                 provider = observationValue.getValue();
-            } else if (observationValue.getObservationValueUid().equals(
-                    serverMetadata.getGaps().getUId()) && observationValue.getValue() != null) {
-                gaps = observationValue.getValue();
             } else if (observationValue.getObservationValueUid().equals(
                     serverMetadata.getPlanAction().getUId()) && observationValue.getValue() != null) {
                 planAction = observationValue.getValue();
@@ -42,7 +38,7 @@ public class ObservationMapper {
 
 
         ObservationViewModel viewModel =
-                new ObservationViewModel(surveyUid, provider, gaps, planAction, action1, action2,
+                new ObservationViewModel(surveyUid, provider, planAction, action1, action2,
                         status);
 
         return viewModel;
@@ -56,11 +52,6 @@ public class ObservationMapper {
         if (!viewModel.getProvider().isEmpty()) {
             values.add(new ObservationValue(viewModel.getProvider(),
                     serverMetadata.getProvider().getUId()));
-        }
-
-        if (!viewModel.getGaps().isEmpty()) {
-            values.add(new ObservationValue(viewModel.getGaps(),
-                    serverMetadata.getGaps().getUId()));
         }
 
         if (!viewModel.getActionPlan().isEmpty()) {

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/ObservationsPresenter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/ObservationsPresenter.java
@@ -170,8 +170,8 @@ public class ObservationsPresenter {
 
     private void showObservation() {
         if (mView != null) {
-            mView.renderBasicObservations(mObservationViewModel.getProvider(),
-                    mObservationViewModel.getGaps(), mObservationViewModel.getActionPlan());
+            mView.renderBasicObservations(mObservationViewModel.getProvider()
+                    , mObservationViewModel.getActionPlan());
 
             if (mObservationViewModel.getAction1().isEmpty()) {
                 mView.selectAction(0);
@@ -239,13 +239,6 @@ public class ObservationsPresenter {
         } else {
             mView.hideSubActionOptionsView();
             mView.hideSubActionOtherView();
-        }
-    }
-
-    public void gaspChanged(String gasp) {
-        if (!gasp.equals(mObservationViewModel.getGaps())) {
-            mObservationViewModel.setGaps(gasp);
-            saveObservation();
         }
     }
 
@@ -407,7 +400,7 @@ public class ObservationsPresenter {
 
         void changeToReadOnlyMode();
 
-        void renderBasicObservations(String provider, String gasp, String actionPlan);
+        void renderBasicObservations(String provider, String actionPlan);
 
         void renderHeaderInfo(String orgUnitName, Float mainScore, String completionDate,
                 String nextDate, CompetencyScoreClassification classification);

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/ObservationViewModel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/ObservationViewModel.java
@@ -8,8 +8,6 @@ public class ObservationViewModel {
 
     String provider = "";
 
-    String gaps = "";
-
     String actionPlan = "";
 
     String action1 = "";
@@ -22,11 +20,10 @@ public class ObservationViewModel {
         this.surveyUid = surveyUid;
     }
 
-    public ObservationViewModel(String surveyUid, String provider, String gaps,
+    public ObservationViewModel(String surveyUid, String provider,
             String actionPlan, String action1, String action2, ObservationStatus status) {
         this.surveyUid = surveyUid;
         this.provider = provider;
-        this.gaps = gaps;
         this.actionPlan = actionPlan;
         this.action1 = action1;
         this.action2 = action2;
@@ -47,14 +44,6 @@ public class ObservationViewModel {
 
     public void setProvider(String provider) {
         this.provider = provider;
-    }
-
-    public String getGaps() {
-        return gaps;
-    }
-
-    public void setGaps(String gaps) {
-        this.gaps = gaps;
     }
 
     public String getActionPlan() {

--- a/app/src/main/res/layout/fragment_observations.xml
+++ b/app/src/main/res/layout/fragment_observations.xml
@@ -236,27 +236,19 @@
                 app:tDimension="@string/font_size_level1"
                 app:tFontName="@string/font_name_regular" />
 
-                <org.eyeseetea.malariacare.views.CustomTextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginRight="@dimen/padding_plan_action_title_left"
-                    android:background="@color/new_blue"
-                    android:paddingBottom="@dimen/margin_feedback_top_bottom_radiobutton"
-                    android:paddingLeft="@dimen/margin_lateral_feedback_radiobutton"
-                    android:paddingTop="@dimen/margin_feedback_top_bottom_radiobutton"
+            <org.eyeseetea.malariacare.views.CustomTextView
+                style="@style/EyeSeeTheme.observation.valueTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/plan_action_provider_title"
+                app:tDimension="@string/font_size_level2"
+                app:tFontName="@string/font_name_medium"/>
 
-                    android:text="@string/plan_action_provider_title"
-                    android:textColor="@color/white"
-                    android:textSize="18dp"
-                    android:textStyle="bold"
-                    app:tDimension="@string/font_size_level2"
-                    app:tFontName="@string/font_name_medium"/>
-
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="1px"
-                    android:layout_marginTop="8dp"
-                    android:background="@color/assess_grey"></View>
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1px"
+                android:layout_marginTop="8dp"
+                android:background="@color/assess_grey"/>
 
             <org.eyeseetea.malariacare.views.CustomEditText
                 android:id="@+id/plan_action_provider_text"
@@ -273,25 +265,18 @@
                 android:scrollbars="none" />
 
             <org.eyeseetea.malariacare.views.CustomTextView
+                style="@style/EyeSeeTheme.observation.valueTitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginRight="@dimen/padding_plan_action_title_left"
-                android:background="@color/new_blue"
-                android:paddingBottom="@dimen/margin_feedback_top_bottom_radiobutton"
-                android:paddingLeft="@dimen/margin_lateral_feedback_radiobutton"
-                android:paddingTop="@dimen/margin_feedback_top_bottom_radiobutton"
                 android:text="@string/plan_action_action_plan_title"
-                android:textColor="@color/white"
-                android:textSize="18dp"
-                android:textStyle="bold"
                 app:tDimension="@string/font_size_level2"
-                app:tFontName="@string/font_name_medium"></org.eyeseetea.malariacare.views.CustomTextView>
+                app:tFontName="@string/font_name_medium"/>
 
             <View
                 android:layout_width="match_parent"
                 android:layout_height="1px"
                 android:layout_marginTop="8dp"
-                android:background="@color/assess_grey"></View>
+                android:background="@color/assess_grey"/>
 
             <org.eyeseetea.malariacare.views.CustomEditText
                 android:id="@+id/plan_action_action_plan_edit_text"
@@ -308,25 +293,18 @@
                 android:scrollbars="none" />
 
             <org.eyeseetea.malariacare.views.CustomTextView
+                style="@style/EyeSeeTheme.observation.valueTitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginRight="@dimen/padding_plan_action_title_left"
-                android:background="@color/new_blue"
-                android:paddingBottom="@dimen/margin_feedback_top_bottom_radiobutton"
-                android:paddingLeft="@dimen/margin_lateral_feedback_radiobutton"
-                android:paddingTop="@dimen/margin_feedback_top_bottom_radiobutton"
                 android:text="@string/plan_action_action_title"
-                android:textColor="@color/white"
-                android:textSize="18dp"
-                android:textStyle="bold"
                 app:tDimension="@string/font_size_level2"
-                app:tFontName="@string/font_name_medium"></org.eyeseetea.malariacare.views.CustomTextView>
+                app:tFontName="@string/font_name_medium"/>
 
             <View
                 android:layout_width="match_parent"
                 android:layout_height="1px"
                 android:layout_marginTop="8dp"
-                android:background="@color/assess_grey"></View>
+                android:background="@color/assess_grey"/>
 
             <org.eyeseetea.malariacare.views.CustomSpinner
                 android:id="@+id/plan_action_spinner"
@@ -344,7 +322,7 @@
                 android:layout_marginLeft="6dp"
                 android:layout_marginRight="14dp"
                 android:layout_marginTop="2dp"
-                android:background="@color/assess_grey"></View>
+                android:background="@color/assess_grey"/>
 
             <org.eyeseetea.malariacare.views.CustomSpinner
                 android:id="@+id/plan_action_secondary_spinner"
@@ -364,7 +342,7 @@
                 android:layout_marginLeft="6dp"
                 android:layout_marginRight="14dp"
                 android:layout_marginTop="2dp"
-                android:background="@color/assess_grey"></View>
+                android:background="@color/assess_grey"/>
 
             <org.eyeseetea.malariacare.views.CustomEditText
                 android:id="@+id/plan_action_others_edit_text"
@@ -386,13 +364,11 @@
                 android:layout_marginLeft="6dp"
                 android:layout_marginRight="14dp"
                 android:layout_marginTop="2dp"
-                android:background="@color/assess_grey"></View>
+                android:background="@color/assess_grey"/>
 
             <View
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/standard_65"
-                android:layout_alignParentBottom="true"
-                android:layout_alignParentRight="true"></View>
+                android:layout_height="@dimen/standard_65" />
         </LinearLayout>
     </ScrollView>
 

--- a/app/src/main/res/layout/plan_action_fragment.xml
+++ b/app/src/main/res/layout/plan_action_fragment.xml
@@ -280,41 +280,6 @@
                 android:paddingBottom="@dimen/margin_feedback_top_bottom_radiobutton"
                 android:paddingLeft="@dimen/margin_lateral_feedback_radiobutton"
                 android:paddingTop="@dimen/margin_feedback_top_bottom_radiobutton"
-                android:text="@string/plan_action_gasp_title"
-                android:textColor="@color/white"
-                android:textSize="18dp"
-                android:textStyle="bold"
-                app:tDimension="@string/font_size_level2"
-                app:tFontName="@string/font_name_medium"></org.eyeseetea.malariacare.views.CustomTextView>
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1px"
-                android:layout_marginTop="8dp"
-                android:background="@color/assess_grey"></View>
-
-            <org.eyeseetea.malariacare.views.CustomEditText
-                android:id="@+id/plan_action_gasp_edit_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_feedback_top_bottom_radiobutton"
-                android:layout_marginLeft="@dimen/margin_lateral_feedback_radiobutton"
-                android:layout_marginRight="@dimen/margin_lateral_feedback_radiobutton"
-                android:layout_marginTop="@dimen/margin_feedback_top_bottom_radiobutton"
-                android:background="@android:color/transparent"
-                android:gravity="top"
-                android:inputType="textMultiLine"
-                android:minLines="5"
-                android:scrollbars="none" />
-
-            <org.eyeseetea.malariacare.views.CustomTextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginRight="@dimen/padding_plan_action_title_left"
-                android:background="@color/new_blue"
-                android:paddingBottom="@dimen/margin_feedback_top_bottom_radiobutton"
-                android:paddingLeft="@dimen/margin_lateral_feedback_radiobutton"
-                android:paddingTop="@dimen/margin_feedback_top_bottom_radiobutton"
                 android:text="@string/plan_action_action_plan_title"
                 android:textColor="@color/white"
                 android:textSize="18dp"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -40,4 +40,18 @@
         <item name="android:textAppearance">?android:textAppearanceLarge</item>
     </style>
 
+    <style name="EyeSeeTheme.observation">
+    </style>
+
+    <style name="EyeSeeTheme.observation.valueTitle">
+        <item name="android:layout_marginRight">@dimen/padding_plan_action_title_left</item>
+        <item name="android:background">@color/new_blue</item>
+        <item name="android:paddingBottom">@dimen/margin_feedback_top_bottom_radiobutton</item>
+        <item name="android:paddingLeft">@dimen/margin_lateral_feedback_radiobutton</item>
+        <item name="android:paddingTop">@dimen/margin_feedback_top_bottom_radiobutton</item>
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textSize">18dp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2270     
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature-eliminate_gaps_section_from_observation Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Eliminate gaps section from observations

### :memo: How is it being implemented?

- I have removed gaps from strings, fragment and layout
- I have removed gaps from view model, mapper and presenter
- I have applied a refactor creating a  style for values titles and rename observations layout

### :boom: How can it be tested?

 **Use case 1:** - Open observations from the feedback screen and the gaps section should not appear

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

![Observations](https://user-images.githubusercontent.com/5593590/56338392-24212f80-61aa-11e9-990c-f2ebeacddb9d.png)

