### PR TITLE
Feature add critical steps missed on observations screen

### DIFF
--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -270,6 +270,7 @@ clínica"</string>
 <string name="schedule_title">Programación de encuesta</string>
 <string name="save">"Salvar"</string>
 <string name="monitor_no_surveys_to_show">"No hay encuesta que mostrar"</string>
+<string name="plan_action_critical_steps_missed_title">"PASOS CRÍTICOS PERDIDOS:"</string>
 <string name="plan_action_provider_title" >"NOMBRE DEL PROVEEDOR:"</string>
 <string name="health_facility">Centro Médico</string>
 <string name="mandatory">"Obligatorio"</string>

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -264,6 +264,7 @@ Mensuelle"</string>
 <string name="schedule_title">"Calendrier de l'enquête"</string>
 <string name="save">"enregistrer"</string>
 <string name="monitor_no_surveys_to_show">"Aucune enquête à afficher"</string>
+<string name="plan_action_critical_steps_missed_title">"ÉTAPES CRITIQUES MANQUÉES:"</string>
 <string name="plan_action_provider_title" >"NOM DU FOURNISSEUR:"</string>
 <string name="health_facility">Centre médical</string>
 <string name="mandatory">"Obligatoire"</string>

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -281,6 +281,7 @@
 <string name="html_text">"អត្ថបទដែលបានធ្វើទ្រង់ទ្រាយ "</string>
 <string name="schedule_title">"កំណត់កាលវិភាគស្ទង់មតិ"</string>
 <string name="monitor_no_surveys_to_show">"គ្មានការស្ទង់មតិដើម្បីបង្ហាញ"</string>
+<string name="plan_action_critical_steps_missed_title">"ជំហានសំខាន់ៗត្រូវបានគេរំលង:"</string>
 <string name="plan_action_provider_title" >"ឈ្មោះក្រុមហ៊ុនផ្ដល់:"</string>
 <string name="health_facility">មជ្ឈមណ្ឌលវេជ្ជសាស្ត្រ</string>
 <string name="mandatory">"ចាំបាច់"</string>

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -277,6 +277,7 @@
 <string name="schedule_title">"ການສໍາຫຼວດຕາຕະລາງ"</string>
 <string name="save">"ຊ່ວຍປະຢັດ"</string>
 <string name="monitor_no_surveys_to_show">"ບໍ່ມີການສໍາຫຼວດທີ່ຈະສະແດງ"</string>
+<string name="plan_action_critical_steps_missed_title">"ຂັ້ນຕອນທີ່ສໍາຄັນທີ່ພາດ້:"</string>
 <string name="plan_action_provider_title" >"ຊື່ຜູ້ໃຫ້ບໍລິການ:"</string>
 <string name="health_facility">ສູນການແພດ</string>
 <string name="mandatory">"ບັງຄັບ"</string>

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -266,6 +266,7 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="schedule_title">"Agendar pesquisa"</string>
 <string name="save">"Salvar"</string>
 <string name="monitor_no_surveys_to_show">"Nenhuma pesquisa para mostrar"</string>
+<string name="plan_action_critical_steps_missed_title">"PASSOS CRÍTICOS PERDIDOS:"</string>
 <string name="plan_action_provider_title" >"NOME DO PROVEEDOR:"</string>
 <string name="health_facility">Centro médico</string>
 <string name="mandatory">"Obrigatório"</string>

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -273,6 +273,7 @@ evaluation"</string>
 <string name="html_text">Formatted text </string>
 <string name="schedule_title">Schedule survey</string>
 <string name="save">"Save"</string>
+<string name="plan_action_critical_steps_missed_title" >"CRITICAL STEPS MISSED:"</string>
 <string name="plan_action_provider_title" >"PROVIDER NAME:"</string>
 <string name="monitor_no_surveys_to_show">"No surveys to show"</string>
 <string name="health_facility">Health Facility</string>

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/CompositeScoreDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/CompositeScoreDB.java
@@ -109,6 +109,10 @@ public class CompositeScoreDB extends BaseModel implements VisitableToSDK {
         this.id_composite_score = id_composite_score;
     }
 
+    public Long getId_composite_score_parent() {
+        return id_composite_score_parent;
+    }
+
     public String getHierarchical_code() { return hierarchical_code; }
 
     public void setHierarchical_code(String hierarchical_code) { this.hierarchical_code = hierarchical_code; }

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
@@ -40,8 +40,6 @@ import android.widget.RelativeLayout;
 
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.database.datasources.ObservationLocalDataSource;
-import org.eyeseetea.malariacare.data.database.model.CompositeScoreDB;
-import org.eyeseetea.malariacare.data.database.model.QuestionDB;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.Session;
@@ -61,14 +59,14 @@ import org.eyeseetea.malariacare.layout.utils.LayoutUtils;
 import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.presentation.presenters.ObservationsPresenter;
-import org.eyeseetea.malariacare.presentation.viewmodels.ObservationViewModel;
+import org.eyeseetea.malariacare.presentation.viewmodels.Observations.CriticalMissedStepViewModel;
+import org.eyeseetea.malariacare.presentation.viewmodels.Observations.ObservationViewModel;
 import org.eyeseetea.malariacare.utils.CompetencyUtils;
 import org.eyeseetea.malariacare.utils.DateParser;
 import org.eyeseetea.malariacare.views.CustomEditText;
 import org.eyeseetea.malariacare.views.CustomSpinner;
 import org.eyeseetea.malariacare.views.CustomTextView;
 
-import java.util.Iterator;
 import java.util.List;
 
 public class ObservationsFragment extends Fragment implements IModuleFragment,
@@ -393,9 +391,8 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
 
     @Override
     public void shareByText(ObservationViewModel observationViewModel, SurveyDB survey,
-            List<QuestionDB> criticalQuestions, List<CompositeScoreDB> compositeScoresTree) {
-        String data = extractTextData(observationViewModel, survey, criticalQuestions,
-                compositeScoresTree);
+            List<CriticalMissedStepViewModel> criticalMissedStepViewModels) {
+        String data = extractTextData(observationViewModel, survey, criticalMissedStepViewModels);
 
         shareData(data);
     }
@@ -423,7 +420,7 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
     }
 
     private String extractTextData(ObservationViewModel observationViewModel, SurveyDB survey,
-            List<QuestionDB> criticalQuestions, List<CompositeScoreDB> compositeScoresTree) {
+            List<CriticalMissedStepViewModel> criticalMissedStepViewModels) {
         String data =
                 PreferencesState.getInstance().getContext().getString(
                         R.string.app_name) + "- \n";
@@ -474,20 +471,17 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
             data += "\n" + observationViewModel.getAction2();
         }
 
-        if (criticalQuestions != null && criticalQuestions.size() > 0) {
+        if (criticalMissedStepViewModels != null && criticalMissedStepViewModels.size() > 0) {
             data += "\n\n" + getString(R.string.critical_steps) + "\n";
 
             //For each score add proper items
-            for (Iterator<CompositeScoreDB> iterator = compositeScoresTree.iterator();
-                    iterator.hasNext(); ) {
-                CompositeScoreDB compositeScore = iterator.next();
-                data += compositeScore.getHierarchical_code() + " " + compositeScore.getLabel()
-                        + "\n";
-                for (QuestionDB question : criticalQuestions) {
-                    if (question.getCompositeScoreFk()
-                            == (compositeScore.getId_composite_score())) {
-                        data += "-" + question.getForm_name() + "\n";
-                    }
+            for (CriticalMissedStepViewModel criticalMissedStepViewModel :
+                    criticalMissedStepViewModels) {
+
+                if (criticalMissedStepViewModel.isCompositeScore()) {
+                    data += criticalMissedStepViewModel.getLabel() + "\n";
+                } else {
+                    data += "-" + criticalMissedStepViewModel.getLabel()  + "\n";
                 }
             }
         }

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/MissedCriticalStepsAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/MissedCriticalStepsAdapter.java
@@ -1,0 +1,93 @@
+package org.eyeseetea.malariacare.layout.adapters;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import org.eyeseetea.malariacare.R;
+import org.eyeseetea.malariacare.presentation.viewmodels.Observations.CompositeScoreViewModel;
+import org.eyeseetea.malariacare.presentation.viewmodels.Observations.MissedCriticalStepViewModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MissedCriticalStepsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+    private List<MissedCriticalStepViewModel> missedCriticalSteps = new ArrayList<>();
+
+    public void setMissedCriticalSteps(List<MissedCriticalStepViewModel> missedCriticalSteps) {
+        this.missedCriticalSteps.clear();
+        this.missedCriticalSteps.addAll(missedCriticalSteps);
+
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup viewGroup, int i) {
+        View itemView = LayoutInflater.from(viewGroup.getContext())
+                .inflate(R.layout.item_missed_critical_step, viewGroup, false);
+        return new ViewHolder(itemView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder viewHolder, int position) {
+        MissedCriticalStepViewModel missedCriticalStep = missedCriticalSteps.get(position);
+
+        ((ViewHolder) viewHolder).bindView(missedCriticalStep);
+    }
+
+    @Override
+    public int getItemCount() {
+        return missedCriticalSteps.size();
+    }
+
+    class ViewHolder extends RecyclerView.ViewHolder {
+        TextView missedCriticalStepTextView;
+        ImageView missedCriticalStepImageView;
+        LinearLayout missedCriticalStepContainer;
+
+        public ViewHolder(View itemView) {
+            super(itemView);
+
+            missedCriticalStepTextView =
+                    itemView.findViewById(R.id.missed_critical_step_text_view);
+            missedCriticalStepImageView =
+                    itemView.findViewById(R.id.missed_critical_step_image_view);
+            missedCriticalStepContainer =
+                    itemView.findViewById(R.id.missed_critical_step_container);
+        }
+
+        void bindView(MissedCriticalStepViewModel missedCriticalStep) {
+            missedCriticalStepTextView.setText(missedCriticalStep.getLabel());
+
+            if (missedCriticalStep.isCompositeScore()) {
+                missedCriticalStepImageView.setVisibility(View.VISIBLE);
+
+                String code = ((CompositeScoreViewModel) missedCriticalStep).getCode();
+
+                //Count number of '.' in string
+                int numDots = code.length() - code.replace(".", "").length();
+
+                if (numDots == 0) {
+                    missedCriticalStepContainer.setBackgroundResource(R.color.feedbackDarkBlue);
+                } else if (numDots == 1) {
+                    missedCriticalStepContainer.setBackgroundResource(R.color.feedbackLightBlue);
+                } else {
+                    missedCriticalStepContainer.setBackgroundResource(R.color.scoreGrandson);
+                }
+
+            } else {
+                missedCriticalStepImageView.setVisibility(View.GONE);
+
+                missedCriticalStepContainer.setBackgroundResource(android.R.color.white);
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/mapper/MissedStepMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/mapper/MissedStepMapper.java
@@ -23,7 +23,10 @@ public class MissedStepMapper {
                 CompositeScoreDB compositeScore = iterator.next();
 
                 CompositeScoreViewModel compositeScoreViewModel = new CompositeScoreViewModel(
-                        compositeScore.getHierarchical_code(), compositeScore.getLabel());
+                        compositeScore.getId_composite_score(),
+                        compositeScore.getId_composite_score_parent(),
+                        compositeScore.getHierarchical_code(),
+                        compositeScore.getLabel());
 
                 missedCriticalStepViewModels.add(compositeScoreViewModel);
 
@@ -31,6 +34,8 @@ public class MissedStepMapper {
                     if (question.getCompositeScoreFk()
                             == (compositeScore.getId_composite_score())) {
                         QuestionViewModel questionViewModel = new QuestionViewModel(
+                                question.getId_question(),
+                                question.getCompositeScoreFk(),
                                 question.getForm_name());
 
                         missedCriticalStepViewModels.add(questionViewModel);

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/mapper/MissedStepMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/mapper/MissedStepMapper.java
@@ -3,7 +3,7 @@ package org.eyeseetea.malariacare.presentation.mapper;
 import org.eyeseetea.malariacare.data.database.model.CompositeScoreDB;
 import org.eyeseetea.malariacare.data.database.model.QuestionDB;
 import org.eyeseetea.malariacare.presentation.viewmodels.Observations.CompositeScoreViewModel;
-import org.eyeseetea.malariacare.presentation.viewmodels.Observations.CriticalMissedStepViewModel;
+import org.eyeseetea.malariacare.presentation.viewmodels.Observations.MissedCriticalStepViewModel;
 import org.eyeseetea.malariacare.presentation.viewmodels.Observations.QuestionViewModel;
 
 import java.util.ArrayList;
@@ -11,10 +11,10 @@ import java.util.Iterator;
 import java.util.List;
 
 public class MissedStepMapper {
-    public static List<CriticalMissedStepViewModel> mapToViewModel(
+    public static List<MissedCriticalStepViewModel> mapToViewModel(
             List<QuestionDB> criticalQuestions, List<CompositeScoreDB> compositeScoresTree) {
 
-        List<CriticalMissedStepViewModel> criticalMissedStepViewModels = new ArrayList<>();
+        List<MissedCriticalStepViewModel> missedCriticalStepViewModels = new ArrayList<>();
 
         if (criticalQuestions != null && criticalQuestions.size() > 0) {
 
@@ -25,7 +25,7 @@ public class MissedStepMapper {
                 CompositeScoreViewModel compositeScoreViewModel = new CompositeScoreViewModel(
                         compositeScore.getHierarchical_code(), compositeScore.getLabel());
 
-                criticalMissedStepViewModels.add(compositeScoreViewModel);
+                missedCriticalStepViewModels.add(compositeScoreViewModel);
 
                 for (QuestionDB question : criticalQuestions) {
                     if (question.getCompositeScoreFk()
@@ -33,12 +33,12 @@ public class MissedStepMapper {
                         QuestionViewModel questionViewModel = new QuestionViewModel(
                                 question.getForm_name());
 
-                        criticalMissedStepViewModels.add(questionViewModel);
+                        missedCriticalStepViewModels.add(questionViewModel);
                     }
                 }
             }
         }
 
-        return criticalMissedStepViewModels;
+        return missedCriticalStepViewModels;
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/mapper/MissedStepMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/mapper/MissedStepMapper.java
@@ -1,0 +1,44 @@
+package org.eyeseetea.malariacare.presentation.mapper;
+
+import org.eyeseetea.malariacare.data.database.model.CompositeScoreDB;
+import org.eyeseetea.malariacare.data.database.model.QuestionDB;
+import org.eyeseetea.malariacare.presentation.viewmodels.Observations.CompositeScoreViewModel;
+import org.eyeseetea.malariacare.presentation.viewmodels.Observations.CriticalMissedStepViewModel;
+import org.eyeseetea.malariacare.presentation.viewmodels.Observations.QuestionViewModel;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class MissedStepMapper {
+    public static List<CriticalMissedStepViewModel> mapToViewModel(
+            List<QuestionDB> criticalQuestions, List<CompositeScoreDB> compositeScoresTree) {
+
+        List<CriticalMissedStepViewModel> criticalMissedStepViewModels = new ArrayList<>();
+
+        if (criticalQuestions != null && criticalQuestions.size() > 0) {
+
+            for (Iterator<CompositeScoreDB> iterator = compositeScoresTree.iterator();
+                    iterator.hasNext(); ) {
+                CompositeScoreDB compositeScore = iterator.next();
+
+                CompositeScoreViewModel compositeScoreViewModel = new CompositeScoreViewModel(
+                        compositeScore.getHierarchical_code(), compositeScore.getLabel());
+
+                criticalMissedStepViewModels.add(compositeScoreViewModel);
+
+                for (QuestionDB question : criticalQuestions) {
+                    if (question.getCompositeScoreFk()
+                            == (compositeScore.getId_composite_score())) {
+                        QuestionViewModel questionViewModel = new QuestionViewModel(
+                                question.getForm_name());
+
+                        criticalMissedStepViewModels.add(questionViewModel);
+                    }
+                }
+            }
+        }
+
+        return criticalMissedStepViewModels;
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/mapper/ObservationMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/mapper/ObservationMapper.java
@@ -4,7 +4,7 @@ import org.eyeseetea.malariacare.domain.entity.Observation;
 import org.eyeseetea.malariacare.domain.entity.ObservationStatus;
 import org.eyeseetea.malariacare.domain.entity.ObservationValue;
 import org.eyeseetea.malariacare.domain.entity.ServerMetadata;
-import org.eyeseetea.malariacare.presentation.viewmodels.ObservationViewModel;
+import org.eyeseetea.malariacare.presentation.viewmodels.Observations.ObservationViewModel;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/ObservationsPresenter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/ObservationsPresenter.java
@@ -18,8 +18,10 @@ import org.eyeseetea.malariacare.domain.usecase.GetObservationBySurveyUidUseCase
 import org.eyeseetea.malariacare.domain.usecase.GetServerMetadataUseCase;
 import org.eyeseetea.malariacare.domain.usecase.SaveObservationUseCase;
 import org.eyeseetea.malariacare.observables.ObservablePush;
+import org.eyeseetea.malariacare.presentation.mapper.MissedStepMapper;
 import org.eyeseetea.malariacare.presentation.mapper.ObservationMapper;
-import org.eyeseetea.malariacare.presentation.viewmodels.ObservationViewModel;
+import org.eyeseetea.malariacare.presentation.viewmodels.Observations.CriticalMissedStepViewModel;
+import org.eyeseetea.malariacare.presentation.viewmodels.Observations.ObservationViewModel;
 import org.eyeseetea.malariacare.utils.DateParser;
 import org.eyeseetea.malariacare.utils.Constants;
 
@@ -323,7 +325,10 @@ public class ObservationsPresenter {
             if (mSurvey.getStatus() != Constants.SURVEY_SENT) {
                 mView.shareNotSent(mContext.getString(R.string.feedback_not_sent));
             } else {
-                mView.shareByText(mObservationViewModel, mSurvey, criticalQuestions, compositeScoresTree);
+                List<CriticalMissedStepViewModel> criticalMissedStepViewModels =
+                        MissedStepMapper.mapToViewModel(criticalQuestions, compositeScoresTree);
+
+                mView.shareByText(mObservationViewModel, mSurvey, criticalMissedStepViewModels);
             }
         }
     }
@@ -422,7 +427,7 @@ public class ObservationsPresenter {
         void updateStatusView(ObservationStatus status);
 
         void shareByText(ObservationViewModel observationViewModel, SurveyDB survey,
-                List<QuestionDB> criticalQuestions, List<CompositeScoreDB> compositeScoresTree);
+                List<CriticalMissedStepViewModel> criticalMissedStepViewModels);
 
         void shareNotSent(String surveyNoSentMessage);
 

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/CompositeScoreViewModel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/CompositeScoreViewModel.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.presentation.viewmodels.Observations;
 
-public class CompositeScoreViewModel extends CriticalMissedStepViewModel {
+public class CompositeScoreViewModel extends MissedCriticalStepViewModel {
     private final String code;
 
     public CompositeScoreViewModel(String code, String name) {
@@ -9,5 +9,7 @@ public class CompositeScoreViewModel extends CriticalMissedStepViewModel {
         this.code = code;
     }
 
-
+    public String getCode() {
+        return code;
+    }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/CompositeScoreViewModel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/CompositeScoreViewModel.java
@@ -2,14 +2,26 @@ package org.eyeseetea.malariacare.presentation.viewmodels.Observations;
 
 public class CompositeScoreViewModel extends MissedCriticalStepViewModel {
     private final String code;
+    private boolean expanded = true;
 
-    public CompositeScoreViewModel(String code, String name) {
-        super(code + " " + name, true);
-
+    public CompositeScoreViewModel(long compositeScoreId, long compositeScoreParentId,
+            String code, String name) {
+        super(COMPOSITE_KEY_PREFIX + compositeScoreId,
+                COMPOSITE_KEY_PREFIX + compositeScoreParentId,
+                code + " " + name, true);
         this.code = code;
     }
 
     public String getCode() {
         return code;
     }
+
+    public boolean isExpanded() {
+        return expanded;
+    }
+
+    public void setExpanded(boolean expanded) {
+        this.expanded = expanded;
+    }
+
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/CompositeScoreViewModel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/CompositeScoreViewModel.java
@@ -1,0 +1,13 @@
+package org.eyeseetea.malariacare.presentation.viewmodels.Observations;
+
+public class CompositeScoreViewModel extends CriticalMissedStepViewModel {
+    private final String code;
+
+    public CompositeScoreViewModel(String code, String name) {
+        super(code + " " + name, true);
+
+        this.code = code;
+    }
+
+
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/CriticalMissedStepViewModel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/CriticalMissedStepViewModel.java
@@ -1,0 +1,20 @@
+package org.eyeseetea.malariacare.presentation.viewmodels.Observations;
+
+public abstract class CriticalMissedStepViewModel {
+
+    private final String label;
+    private final boolean isCompositeScore;
+
+    public CriticalMissedStepViewModel(String label, boolean isCompositeScore) {
+        this.label = label;
+        this.isCompositeScore = isCompositeScore;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public boolean isCompositeScore() {
+        return isCompositeScore;
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/MissedCriticalStepViewModel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/MissedCriticalStepViewModel.java
@@ -4,10 +4,30 @@ public abstract class MissedCriticalStepViewModel {
 
     private final String label;
     private final boolean isCompositeScore;
+    private boolean visible = true;
+    private String parentKey;
+    private String key;
 
-    public MissedCriticalStepViewModel(String label, boolean isCompositeScore) {
+    protected static String COMPOSITE_KEY_PREFIX = "C-";
+    protected static String QUESTION_KEY_PREFIX = "Q-";
+
+    public MissedCriticalStepViewModel(
+            String key,
+            String parentKey,
+            String label,
+            boolean isCompositeScore) {
+        this.key = key;
+        this.parentKey = parentKey;
         this.label = label;
         this.isCompositeScore = isCompositeScore;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getParentKey() {
+        return parentKey;
     }
 
     public String getLabel() {
@@ -16,5 +36,13 @@ public abstract class MissedCriticalStepViewModel {
 
     public boolean isCompositeScore() {
         return isCompositeScore;
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+
+    public void setVisible(boolean visible) {
+        this.visible = visible;
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/MissedCriticalStepViewModel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/MissedCriticalStepViewModel.java
@@ -1,11 +1,11 @@
 package org.eyeseetea.malariacare.presentation.viewmodels.Observations;
 
-public abstract class CriticalMissedStepViewModel {
+public abstract class MissedCriticalStepViewModel {
 
     private final String label;
     private final boolean isCompositeScore;
 
-    public CriticalMissedStepViewModel(String label, boolean isCompositeScore) {
+    public MissedCriticalStepViewModel(String label, boolean isCompositeScore) {
         this.label = label;
         this.isCompositeScore = isCompositeScore;
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/ObservationViewModel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/ObservationViewModel.java
@@ -1,4 +1,4 @@
-package org.eyeseetea.malariacare.presentation.viewmodels;
+package org.eyeseetea.malariacare.presentation.viewmodels.Observations;
 
 import org.eyeseetea.malariacare.domain.entity.ObservationStatus;
 

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/QuestionViewModel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/QuestionViewModel.java
@@ -1,6 +1,6 @@
 package org.eyeseetea.malariacare.presentation.viewmodels.Observations;
 
-public class QuestionViewModel extends CriticalMissedStepViewModel {
+public class QuestionViewModel extends MissedCriticalStepViewModel {
     public QuestionViewModel(String name) {
         super(name, false);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/QuestionViewModel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/QuestionViewModel.java
@@ -1,7 +1,9 @@
 package org.eyeseetea.malariacare.presentation.viewmodels.Observations;
 
 public class QuestionViewModel extends MissedCriticalStepViewModel {
-    public QuestionViewModel(String name) {
-        super(name, false);
+    public QuestionViewModel(long questionId, long compositeScoreParentId, String name) {
+        super(QUESTION_KEY_PREFIX + questionId,
+                COMPOSITE_KEY_PREFIX + compositeScoreParentId,
+                name, false);
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/QuestionViewModel.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/viewmodels/Observations/QuestionViewModel.java
@@ -1,0 +1,7 @@
+package org.eyeseetea.malariacare.presentation.viewmodels.Observations;
+
+public class QuestionViewModel extends CriticalMissedStepViewModel {
+    public QuestionViewModel(String name) {
+        super(name, false);
+    }
+}

--- a/app/src/main/res/layout/fragment_observations.xml
+++ b/app/src/main/res/layout/fragment_observations.xml
@@ -212,7 +212,7 @@
         </RelativeLayout>
     </LinearLayout>
 
-    <ScrollView
+    <android.support.v4.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_alignParentBottom="true"
@@ -235,6 +235,28 @@
                 android:textSize="@dimen/xsmall_text_size"
                 app:tDimension="@string/font_size_level1"
                 app:tFontName="@string/font_name_regular" />
+
+            <org.eyeseetea.malariacare.views.CustomTextView
+                style="@style/EyeSeeTheme.observation.valueTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/plan_action_critical_steps_missed_title"
+                app:tDimension="@string/font_size_level2"
+                app:tFontName="@string/font_name_medium"/>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1px"
+                android:layout_marginTop="8dp"
+                android:background="@color/assess_grey"/>
+
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/missed_critical_steps_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layoutManager="android.support.v7.widget.LinearLayoutManager">
+
+            </android.support.v7.widget.RecyclerView>
 
             <org.eyeseetea.malariacare.views.CustomTextView
                 style="@style/EyeSeeTheme.observation.valueTitle"
@@ -370,6 +392,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/standard_65" />
         </LinearLayout>
-    </ScrollView>
+    </android.support.v4.widget.NestedScrollView>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/item_missed_critical_step.xml
+++ b/app/src/main/res/layout/item_missed_critical_step.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/missed_critical_step_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:background="@color/white">
+
+    <org.eyeseetea.sdk.presentation.views.CustomTextView
+        android:id="@+id/missed_critical_step_text_view"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="0.9"
+        android:background="@color/transparent"
+        android:ellipsize="end"
+        android:textColor="@color/darkGrey"
+        android:textSize="16sp"
+        android:layout_marginRight="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:gravity="center_vertical"
+        app:font_name="@string/font_name_medium"
+        app:tDimension="@string/font_size_level4"/>
+
+    <ImageView
+        android:id="@+id/missed_critical_step_image_view"
+        android:layout_width="0dp"
+        android:layout_height="36dp"
+        android:layout_gravity="center"
+        android:layout_weight="0.1"
+        android:src="@drawable/ic_media_arrow"/>
+</LinearLayout>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2272     
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature-add_critical_steps_missed_on_observations_screen Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Add critical steps missed with collapsable sections in Observations screen with expand /collapse actions.

### :memo: How is it being implemented?

- I have applied a refactor creating view models to represent missed critical steps (composite score and questions) and I have used view models to shared by text
- I have added Missed Critical Steps in observations
- I have added Expand/Collapse actions 

### :boom: How can it be tested?

 **Use case 1:** - Create a new survey with missed critical steps and navigate to observations. A new missed critical steps section should appear with expand/collapse actions.

 **Use case 2:** - Create a new survey with missed critical steps and navigate to observations. To share a missed critical steps section should appear like in the last version.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

![missed_critical_steps](https://user-images.githubusercontent.com/5593590/56419707-7beb9380-629b-11e9-9fbf-f67489097084.png)
