### PR TITLE
Refactor PushService to JobIntentService to avoid bugs in Android 8

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
 
         <service
             android:name=".services.PushService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false" />
 
         <service

--- a/app/src/main/java/org/eyeseetea/malariacare/receivers/AlarmPushReceiver.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/receivers/AlarmPushReceiver.java
@@ -80,7 +80,8 @@ public class AlarmPushReceiver extends BroadcastReceiver {
         Log.d(TAG, "onReceive asking for push");
         Intent pushIntent = new Intent(context, PushService.class);
         pushIntent.putExtra(SurveyService.SERVICE_METHOD, PushService.PENDING_SURVEYS_ACTION);
-        context.startService(pushIntent);
+
+        PushService.enqueueWork(context, pushIntent);
     }
 
     public void setPushAlarm(Context context) {

--- a/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
@@ -20,8 +20,10 @@
 
 package org.eyeseetea.malariacare.services;
 
-import android.app.IntentService;
+import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
 
 import org.eyeseetea.malariacare.data.database.datasources.ServerInfoLocalDataSource;
 import org.eyeseetea.malariacare.data.database.iomodules.dhis.exporter.PushController;
@@ -36,7 +38,7 @@ import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.strategies.PushServiceStrategy;
 
-public class PushService extends IntentService {
+public class PushService extends JobIntentService {
     /**
      * Constant added to the intent in order to reuse the service for different 'methods'
      */
@@ -53,26 +55,16 @@ public class PushService extends IntentService {
     IPushController pushController;
     PushUseCase pushUseCase;
 
+    public static final int JOB_ID = 1;
+
     PushServiceStrategy mPushServiceStrategy = new PushServiceStrategy(this);
 
-    /**
-     * Constructor required due to a error message in AndroidManifest.xml if it is not present
-     */
-    public PushService() {
-        super(PushService.class.getSimpleName());
-    }
-
-    /**
-     * Creates an IntentService. Invoked by your subclass's constructor.
-     *
-     * @param name Used to name the worker thread, important only for debugging.
-     */
-    public PushService(String name) {
-        super(name);
+    public static void enqueueWork(Context context, Intent work) {
+        enqueueWork(context, PushService.class, JOB_ID, work);
     }
 
     @Override
-    protected void onHandleIntent(Intent intent) {
+    protected void onHandleWork(@NonNull Intent intent) {
         //Ignore wrong actions
         if (!PENDING_SURVEYS_ACTION.equals(intent.getStringExtra(SERVICE_METHOD))) {
             return;


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2279 
* **Related pull-requests:** 

### :tophat: What is the goal?

Fix push service bugs when the app is on the background.

###   :gear: branches 
**app**:
       Origin: maintenance-push_service_error_android_8 Target: v1.4_hnqis
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
**SDK**:
       Origin: feature-2.30_upgrade_gradle
       
### :memo: How is it being implemented?
From Android 8 background service has limitations and jobscheduler should be used.
Support library added a new service called JobIntentService that manage this logic and I used it.

https://developer.android.com/about/versions/oreo/background
https://developer.android.com/reference/android/support/v4/app/JobIntentService.html

### :boom: How can it be tested?

**Use Case 1**:  Create a new survey and wait until push start, the push should be realized successfully.
**Use Case 2**:  Send the app to background starting a new app, the push service should be invoked indefinitely without bugs.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots