### PR TITLE
Get non translated code for competency CDE in push process

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -540,8 +540,7 @@ public class ConvertToSDKVisitor implements
 
         //Competency
         if (controlDataElementExistsInServer(overallCompetencyCode) && survey.hasMainScore()) {
-            addOrUpdateDataValue(overallCompetencyCode,
-                    CompetencyUtils.getTextByCompetencyAbbreviation(competency, context));
+            addOrUpdateDataValue(overallCompetencyCode, competency.getCode());
         }
 
         //Competency competent


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2319         
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: bug/pushing_translated_competency_code Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Push competency code without translation

### :memo: How is it being implemented?

In push process use not translated competency code

### :boom: How can it be tested?

 **Use case 1:** - Create a new survey and wait to push. Should be pushed with non translated competency code

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
