### PR TITLE
fix server logo exception when no conexion

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/BaseActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/BaseActivity.java
@@ -142,7 +142,7 @@ public abstract class BaseActivity extends AppCompatActivity {
             setTheme(R.style.EyeSeeTheme);
             android.support.v7.app.ActionBar actionBar = BaseActivity.this.getSupportActionBar();
 
-            if (server.getLogo() != null){
+            if (server != null && server.getLogo() != null){
                 LayoutUtils.setActionBarLogo(this, actionBar, server.getLogo());
             } else{
                 LayoutUtils.setActionBarLogo(actionBar);

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/ModuleController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/ModuleController.java
@@ -224,7 +224,7 @@ public abstract class ModuleController {
 
     public void setActionBarDashboard() {
         serverUseCase.execute(server -> {
-            if (server.getName() != null && !server.getName().isEmpty()){
+            if (server != null && server.getName() != null && !server.getName().isEmpty()){
                 LayoutUtils.setActionBarDashboard(dashboardActivity, server.getName(),getTitle());
             } else {
                 LayoutUtils.setActionBarDashboard(dashboardActivity, getTitle());


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/malariapp/issues/2325

###   :gear: branches 
**app**: 
       Origin: bug/null_exception_server_logo Target: v1.4_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       development
**SDK**: 
       feature/fix_build_gradle_warnings

### :tophat: What is the goal?

Fix null exception

### :memo: How is it being implemented?

- I have added null check before asign null value

### :boom: How can it be tested?

1: install and login using v1.4_hnqis version without latest update
2: Turn on flight mode
3: install and run v1.4_hnqis updated. The application will be crashed.
3: install this version. The application will work correctly
4: Turn off flight mode. The application still works.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
