### PR TITLE
1.4.2 Fix some problems in feedback layout

### DIFF
--- a/app/src/hnqis/res/layout/feedback_composite_score_row.xml
+++ b/app/src/hnqis/res/layout/feedback_composite_score_row.xml
@@ -20,31 +20,30 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:background="@color/transparent"
     android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:background="@color/white"
         android:orientation="horizontal"
         android:weightSum="1">
     <LinearLayout
         android:id="@+id/cs_header"
         android:layout_width="0dp"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_weight=".74"
-        android:weightSum=".74">
+        android:weightSum=".74"
+        android:gravity="center_vertical">
 
         <org.eyeseetea.malariacare.views.CustomTextView
             android:id="@+id/feedback_label"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight=".62"
-            android:paddingBottom="@dimen/dashboard_row_padding"
-            android:paddingLeft="@dimen/dashboard_row_padding"
-            android:paddingTop="@dimen/dashboard_row_padding"
+            android:padding="@dimen/dashboard_row_padding"
             android:text="@string/lorem_ipsum"
             android:textColor="@color/white"
             android:textStyle="bold"
@@ -58,27 +57,20 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight=".12"
-            android:background="@null"
             android:paddingBottom="@dimen/dashboard_row_padding"
             android:paddingLeft="@dimen/dashboard_row_padding"
             android:paddingTop="@dimen/dashboard_row_padding"
-            android:src="@drawable/ic_media_arrow"
-            android:textStyle="bold"
-            android:tintMode="src_over"
-            android:typeface="sans" />
+            app:srcCompat="@drawable/ic_arrow_drop_up" />
     </LinearLayout>
 
     <org.eyeseetea.malariacare.views.CustomTextView
         android:id="@+id/feedback_score_label"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_gravity="right"
         android:layout_weight=".26"
         android:background="@color/white"
         android:gravity="center"
-        android:paddingBottom="@dimen/dashboard_row_padding"
-        android:paddingLeft="@dimen/dashboard_row_padding"
-        android:paddingTop="@dimen/dashboard_row_padding"
         android:text="@string/lorem_ipsum"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="@color/white"

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/FeedbackAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/FeedbackAdapter.java
@@ -161,17 +161,16 @@ public class FeedbackAdapter extends BaseAdapter {
 
         rowLayout.findViewById(R.id.cs_header).setBackgroundResource(feedback.getBackgroundColor());
 
-        ImageView imageView = (ImageView)rowLayout.findViewById(R.id.feedback_image);
-        imageView.setBackgroundResource(feedback.getBackgroundColor());
+        ImageView imageView = rowLayout.findViewById(R.id.feedback_image);
         if(feedback.getFeedbackList().size()==0 && feedback.getCompositeScoreFeedbackList().size()==0){
             imageView.setVisibility(View.GONE);
         }else{
             if((feedback.getFeedbackList().size()>0 && feedback.getFeedbackList().get(0).isShown()) ||
                     (feedback.getCompositeScoreFeedbackList().size()>0 && feedback.getCompositeScoreFeedbackList().get(0).isShown()))
             {
-                imageView.setImageDrawable(parent.getContext().getResources().getDrawable(R.drawable.ic_media_arrow_up));
+                imageView.setImageResource(R.drawable.ic_arrow_drop_up);
             }else{
-                imageView.setImageDrawable(parent.getContext().getResources().getDrawable(R.drawable.ic_media_arrow));
+                imageView.setImageResource(R.drawable.ic_arrow_drop_down);
             }
 
         }

--- a/app/src/main/res/drawable/ic_arrow_drop_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_drop_down.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,10l5,5 5,-5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_arrow_drop_up.xml
+++ b/app/src/main/res/drawable/ic_arrow_drop_up.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M7,14l5,-5 5,5z"/>
+</vector>

--- a/app/src/main/res/layout/feedback_composite_score_row.xml
+++ b/app/src/main/res/layout/feedback_composite_score_row.xml
@@ -20,74 +20,66 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:background="@color/transparent"
     android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:background="@color/white"
         android:orientation="horizontal"
         android:weightSum="1">
-    <LinearLayout
-        android:id="@+id/cs_header"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight=".74"
-        android:weightSum=".74">
-
-        <org.eyeseetea.malariacare.views.CustomTextView
-            android:id="@+id/feedback_label"
+        <LinearLayout
+            android:id="@+id/cs_header"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight=".62"
-            android:paddingBottom="@dimen/dashboard_row_padding"
-            android:paddingLeft="@dimen/dashboard_row_padding"
-            android:paddingTop="@dimen/dashboard_row_padding"
+            android:layout_weight=".74"
+            android:weightSum=".74"
+            android:gravity="center_vertical">
+
+            <org.eyeseetea.malariacare.views.CustomTextView
+                android:id="@+id/feedback_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".62"
+                android:padding="@dimen/dashboard_row_padding"
+                android:text="@string/lorem_ipsum"
+                android:textColor="@color/white"
+                android:textStyle="bold"
+                android:typeface="sans"
+                android:textSize="18dp"
+                app:tDimension="@string/font_size_level2"
+                app:tFontName="@string/condensed_font_name" />
+
+            <ImageView
+                android:id="@+id/feedback_image"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".12"
+                android:paddingBottom="@dimen/dashboard_row_padding"
+                android:paddingLeft="@dimen/dashboard_row_padding"
+                android:paddingTop="@dimen/dashboard_row_padding"
+                app:srcCompat="@drawable/ic_arrow_drop_up" />
+        </LinearLayout>
+
+        <org.eyeseetea.malariacare.views.CustomTextView
+            android:id="@+id/feedback_score_label"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_gravity="right"
+            android:layout_weight=".26"
+            android:background="@color/white"
+            android:gravity="center"
             android:text="@string/lorem_ipsum"
+            android:textAppearance="?android:attr/textAppearanceSmall"
             android:textColor="@color/white"
             android:textStyle="bold"
             android:typeface="sans"
-            android:textSize="18dp"
             app:tDimension="@string/font_size_level2"
-            app:tFontName="@string/condensed_font_name" />
+            app:tFontName="@string/medium_font_name" />
 
-        <ImageView
-            android:id="@+id/feedback_image"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight=".12"
-            android:background="@null"
-            android:paddingBottom="@dimen/dashboard_row_padding"
-            android:paddingLeft="@dimen/dashboard_row_padding"
-            android:paddingTop="@dimen/dashboard_row_padding"
-            android:src="@drawable/ic_media_arrow"
-            android:textStyle="bold"
-            android:tintMode="src_over"
-            android:typeface="sans" />
     </LinearLayout>
-
-    <org.eyeseetea.malariacare.views.CustomTextView
-        android:id="@+id/feedback_score_label"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="right"
-        android:layout_weight=".22"
-        android:background="@color/white"
-        android:gravity="right"
-        android:paddingBottom="@dimen/dashboard_row_padding"
-        android:paddingLeft="@dimen/dashboard_row_padding"
-        android:paddingTop="@dimen/dashboard_row_padding"
-        android:text="@string/lorem_ipsum"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="@color/white"
-        android:textStyle="bold"
-        android:typeface="sans"
-        app:tDimension="@string/font_size_level2"
-        app:tFontName="@string/medium_font_name" />
-
-        </LinearLayout>
     <View
         android:layout_width="match_parent"
         android:layout_height="1px"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2330           
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: bug/1_4_2_cut_out_feedback_headers Target: v1.4_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

In improve module, the lower end of headers are appearing partially cut-out.

### :memo: How is it being implemented?

Feedback layout had several bugs:
- The whole layout was conditioned by a big arrow image, I have added two new vector images to arrow up and down
- If the header was two lines, the second line was hidden
- The height for containers was assigned as match parent, I have modified it to warp_content

### :boom: How can it be tested?

** Use case 1**: navigate to feedback and verify that headers do not appear cut-out.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [X] Yeap, here you have some screenshots-

With bugs:
![LayoutBugsFeedback](https://user-images.githubusercontent.com/5593590/62442875-93bb2a80-b759-11e9-8b72-b906f7b46e0b.png)

Without bugs:
![FixedLayoutFeedback](https://user-images.githubusercontent.com/5593590/62442884-974eb180-b759-11e9-9e78-c164acb311f5.png)

