### PR TITLE
Mark with specific status when a survey fail the conversion to push

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/domain/exception/ConversionException.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/exception/ConversionException.java
@@ -1,15 +1,41 @@
 package org.eyeseetea.malariacare.domain.exception;
 
+import org.eyeseetea.malariacare.data.database.model.ObsActionPlanDB;
+import org.eyeseetea.malariacare.data.database.model.SurveyDB;
+
+
 public class ConversionException extends Exception {
+    private SurveyDB conversionFailedSurvey;
+    private ObsActionPlanDB conversionFailedObsPan;
+
+    public ConversionException() {
+        super("Error in conversion");
+    }
+
+    public ConversionException(String message) {
+        super("Error in survey conversion: " + message);
+    }
+
     public ConversionException(Exception e) {
         super("Error in conversion" + e.getMessage());
         e.printStackTrace();
     }
-    public ConversionException(String message) {
-        super("Error in conversion"+ message);
-        System.out.println(ConversionException.class.getName() + message);
+
+    public ConversionException(SurveyDB conversionFailedSurvey, String message) {
+        super("Error in survey conversion: " + message);
+        this.conversionFailedSurvey = conversionFailedSurvey;
     }
-    public ConversionException() {
-        super("Error in conversion");
+
+    public ConversionException(ObsActionPlanDB conversionFailedObsPan, String message) {
+        super("Error in obs & action plan conversion: " + message);
+        this.conversionFailedObsPan = conversionFailedObsPan;
+    }
+
+    public SurveyDB getConversionFailedSurvey() {
+        return conversionFailedSurvey;
+    }
+
+    public ObsActionPlanDB getConversionFailedObsPan() {
+        return conversionFailedObsPan;
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/Constants.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/Constants.java
@@ -54,7 +54,9 @@ public class Constants {
             SURVEY_HIDE = 3,
             SURVEY_CONFLICT = 4,
             SURVEY_QUARANTINE = 5,
-            SURVEY_SENDING = 6;
+            SURVEY_SENDING = 6,
+            SURVEY_SYNC_CONVERSION_ERROR = 7;
+
 
     //############# OPERATION TYPE ##############
     public static final int OPERATION_TYPE_MATCH = 0,


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2331           
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance/1_4_avoid_delete_surveys_when_occur_an_error_conversion_to_sync Target: v1.4_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

The client report this:
Since the update to 1.4.2, some users from some countries (Kenya, Nepal, Nigeria, Uganda) have reported assessments disappearing from the app. It has taken some time to replicate the error and document it. See ppt* which illustrates assessments conducted and correctly showing up in Plan module and not showing up in Improve and Monitor. Assessments are correctly found in DHIS2, as well.

Reviewing the code when a conversion occurs in the push process, the survey is deleted.
The goal is never to delete user-created surveys.

### :memo: How is it being implemented?

when a conversion occurs in the push process, the survey is marked with a new status
 SURVEY_SYNC_CONVERSION_ERROR = 7;

### :boom: How can it be tested?

Modify the code temporarily to provoke the conversion errors.

In the class ConvertToSDKVisitor modify method buildEvent adding this as first step :
        if (currentEvent != null){
            throw new Exception ("Testing exception");
        }
In the class ConvertToSDKVisitor modify method buildSentEvent adding this as first step :
        if (currentEvent != null){
            throw new Exception ("Testing exception");
        }

**UseCase 1**: create a new survey and wait to push, then the survey sync should fail and save survey status as SURVEY_SYNC_CONVERSION_ERROR = 7

**UseCase 2**: create a new observation & action plan and wait to push, then the observation & action plan sync should fail and save observation & action plan status as SURVEY_SYNC_CONVERSION_ERROR = 7

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-