### PR TITLE
Communicate to downloadManager the complete exportation to download f…

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/ExportData.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/ExportData.java
@@ -1,5 +1,7 @@
 package org.eyeseetea.malariacare.data.database.utils;
 
+import static android.content.Context.DOWNLOAD_SERVICE;
+
 import android.Manifest;
 import android.app.Activity;
 import android.app.DownloadManager;
@@ -96,13 +98,13 @@ public class ExportData {
         File compressedFile = dumpAndCompress(activity);
 
         if (compressedFile != null) {
-            result = exportToDownloadsFolder(compressedFile);
+            result = exportToDownloadsFolder(activity, compressedFile);
         }
 
         return result;
     }
 
-    private static boolean exportToDownloadsFolder(File compressedFile) {
+    private static boolean exportToDownloadsFolder(Activity activity, File compressedFile) {
         boolean result = false;
 
         File download_folder = Environment.getExternalStoragePublicDirectory(
@@ -116,6 +118,15 @@ public class ExportData {
         } catch (IOException e) {
             e.printStackTrace();
         }
+
+        // This code communicate to downloadManager and It's necessary to:
+        // - show notification
+        // - turn visible the file for old devices in downloads folder
+        DownloadManager downloadManager = (DownloadManager) activity.getSystemService(DOWNLOAD_SERVICE);
+
+        downloadManager.addCompletedDownload(exportDataFile.getName(), exportDataFile.getName(),
+                true, "application/zip",
+                exportDataFile.getAbsolutePath(),exportDataFile.length(),true);
 
         return result;
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2335           
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance/1_4_exported_db_does_not_appear_in_dowloads Target: v1.4_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Fix exportDB to local storage in Android 4.4.2

### :memo: How is it being implemented?

In Android 4.4.2, the file is exported successfully but the file does not appear in download folder.

After download, I have added a code to communicate to DownloadManager the completed exportation.

This provokes the next:
- show notification
- turn visible the file for old devices in the downloads folder 

### :boom: How can it be tested?

**UseCase 1**: in Android 4.4.2, open the app and export to local storage, the zip file should appear in the download folder.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-