### PR TITLE
Fix crash creating survey from assess module

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/CreateSurveyFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/CreateSurveyFragment.java
@@ -476,7 +476,7 @@ public class CreateSurveyFragment extends Fragment {
         ProgramDB lastSelectedProgram= getLastSelectedProgram();
 
         String programUidFilter = filter.getSelectedProgramFilter();
-        if(programUidFilter!=null){
+        if(!programUidFilter.isEmpty()){
             ProgramDB filteredProgram = ProgramDB.getProgram(programUidFilter);
             programView.setSelection(getIndex(programView, filteredProgram.getName()));
         }else {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2353  
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance/fix_crash_creating_survey_from_assess_module Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Fix crash creating a survey from assess module

### :memo: How is it being implemented?

- From uncouple refactor of OrgUnitProgramFilterView from db models in the last release, now when all surveys and programs filter are selected then return an empty string.
I have replaced empty filter verification from null to empty string.

### :boom: How can it be tested?

**Use case 1:** - Select All programs and org units in the shared filters then try create a new survey from assess module and should work.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
