### PR TITLE
Use GsonConverterFactory because JacksonConverterFactory for kotlin c…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -191,12 +191,11 @@ dependencies {
 
     implementation "com.google.code.findbugs:jsr305:${libs.jsr305Version}"
 
+
     // Square
     implementation "com.squareup.okhttp3:okhttp:${libs.okhttpVersion}"
     implementation "com.squareup.retrofit2:retrofit:${libs.retrofitVersion}"
-    implementation "com.squareup.retrofit2:converter-jackson:${libs.retrofitVersion}"
-
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${libs.jacksonModuleKotlin}"
+    implementation "com.squareup.retrofit2:converter-gson:${libs.retrofitVersion}"
 
     // Unit testing dependencies
     testImplementation "junit:junit:${libs.jUnitVersion}"
@@ -245,7 +244,6 @@ dependencies {
         exclude group: "com.google.android.gms"
     }
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
 }
 
 check.dependsOn ktlint

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/poeditor/PoEditorApiClient.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/poeditor/PoEditorApiClient.kt
@@ -1,10 +1,9 @@
 package org.eyeseetea.malariacare.data.remote.poeditor
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import okhttp3.OkHttpClient
 import org.eyeseetea.malariacare.domain.common.Either
 import retrofit2.Retrofit
-import retrofit2.converter.jackson.JacksonConverterFactory
+import retrofit2.converter.gson.GsonConverterFactory
 import java.io.IOException
 
 sealed class PoEditorApiClientFailure {
@@ -34,7 +33,7 @@ class PoEditorApiClient(private val projectID: String, private val apiToken: Str
 
     init {
         val retrofit: Retrofit = Retrofit.Builder()
-            .addConverterFactory(JacksonConverterFactory.create(jacksonObjectMapper()))
+            .addConverterFactory(GsonConverterFactory.create())
             .client(OkHttpClient.Builder().build())
             .baseUrl("https://api.poeditor.com/")
             .build()


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2391   
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance/fix_pull_metadata_programs_bu Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Fix pull process becuase programs and events after pull are empty

### :memo: How is it being implemented?

-  the problem is conflict between jacksonconverter for kotlin and SDK.
I have used GsonConverter

### :boom: How can it be tested?

**Use case 1:** - Pull should work

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-