### PR TITLE
Change date title in monitoring to Comp date

### DIFF
--- a/app/src/main/res/layout/item_survey_detail.xml
+++ b/app/src/main/res/layout/item_survey_detail.xml
@@ -64,7 +64,7 @@
                 android:ellipsize="end"
                 android:lines="1"
                 android:textSize="@dimen/planing_text_size"
-                android:text="@string/dashboard_title_planned_next_qa"
+                android:text="@string/assessment_sent_date"
                 app:tDimension="@string/font_size_level1"
                 app:tFontName="@string/medium_font_name"/>
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2401   
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance/monitor_change_date_title_to_comp_date Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Change title in monitoring for date to Comp date

### :memo: How is it being implemented?

- Simply change the title 

### :boom: How can it be tested?

**Use case 1:** - navigate to monitoring and the title for the date should be Comp date

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-