### PR TITLE
Changes in competency classes:

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/QuestionDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/QuestionDB.java
@@ -931,6 +931,22 @@ public class QuestionDB extends BaseModel {
                 .queryList();
     }
 
+    public static List<QuestionDB> getAnsweredQuestions(long idSurvey, boolean critical) {
+        return SQLite.select()
+                .from(QuestionDB.class).as(questionName)
+                .join(ValueDB.class, Join.JoinType.LEFT_OUTER).as(valueName)
+                .on(ValueDB_Table.id_question_fk.withTable(valueAlias)
+                        .eq(QuestionDB_Table.id_question.withTable(questionAlias)))
+                .join(OptionDB.class, Join.JoinType.LEFT_OUTER).as(optionFlowName)
+                .on(OptionDB_Table.id_answer_fk.withTable(optionFlowAlias)
+                        .eq(QuestionDB_Table.id_answer_fk.withTable(questionAlias)))
+                .where(ValueDB_Table.id_survey_fk.eq(idSurvey))
+                .and(QuestionDB_Table.compulsory.is(critical))
+                .and(ValueDB_Table.value.withTable(valueAlias).is(OptionDB_Table.name.withTable(optionFlowAlias)))
+                .queryList();
+    }
+
+
     public static List<CompositeScoreDB> getCompositeScoreOfFailedQuestions(long idSurvey, boolean critical) {
         return new Select()
                 .from(CompositeScoreDB.class).as(compositeScoreName)

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/service/CompetencyScoreCalculationDomainService.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/service/CompetencyScoreCalculationDomainService.java
@@ -23,16 +23,20 @@ import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 
 public class CompetencyScoreCalculationDomainService {
 
-    public final static float NON_CRITICAL_COMPETENT_SCORE_LIMIT = 90f;
-    public final static float NON_CRITICAL_COMPETENT_NEEDS_IMPROVEMENT_SCORE_LIMIT = 80f;
+    public final static float NON_CRITICAL_COMPETENT_SCORE_LIMIT = 89.9f;
+    public final static float NON_CRITICAL_COMPETENT_NEEDS_IMPROVEMENT_SCORE_LIMIT = 79.9f;
 
     public CompetencyScoreClassification calculateClassification(
-            boolean hasCriticalStepsMissed, Float nonCriticalStepsScore) {
+            boolean hasCriticalStepsMissed,
+            Float nonCriticalStepsScore,
+            boolean anyNonCriticalStepsAnswered) {
 
-        if (!hasCriticalStepsMissed){
-            if(nonCriticalStepsScore>= NON_CRITICAL_COMPETENT_SCORE_LIMIT){
+        if (!hasCriticalStepsMissed) {
+            if (nonCriticalStepsScore >= NON_CRITICAL_COMPETENT_SCORE_LIMIT
+                    || anyNonCriticalStepsAnswered) {
                 return CompetencyScoreClassification.COMPETENT;
-            } else if (nonCriticalStepsScore >= NON_CRITICAL_COMPETENT_NEEDS_IMPROVEMENT_SCORE_LIMIT){
+            } else if (nonCriticalStepsScore
+                    >= NON_CRITICAL_COMPETENT_NEEDS_IMPROVEMENT_SCORE_LIMIT) {
                 return CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT;
             } else {
                 return CompetencyScoreClassification.NOT_COMPETENT;

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/CompleteSurveyUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/CompleteSurveyUseCase.java
@@ -59,9 +59,13 @@ public class CompleteSurveyUseCase implements UseCase {
                     ScoreRegister.calculateScoreForNonCriticalsSteps(surveyDB,
                             "nonCriticalStepsScore");
 
+            List<QuestionDB> nonCriticalAnsweredQuestions =
+                    QuestionDB.getAnsweredQuestions(surveyDB.getId_survey(), false);
+
             CompetencyScoreClassification competencyScoreClassification =
                     competencyScoreCalculationDomainService.calculateClassification(
-                            criticalFailedQuestions.size() > 0, nonCriticalStepsScore);
+                            criticalFailedQuestions.size() > 0, nonCriticalStepsScore,
+                            nonCriticalAnsweredQuestions.size() == 0);
 
             surveyDB.setCompetencyScoreClassification(competencyScoreClassification.getId());
 

--- a/app/src/test/java/org/eyeseetea/malariacare/domain/service/CompetencyScoreCalculationDomainServiceShould.java
+++ b/app/src/test/java/org/eyeseetea/malariacare/domain/service/CompetencyScoreCalculationDomainServiceShould.java
@@ -2,14 +2,13 @@ package org.eyeseetea.malariacare.domain.service;
 
 import static org.eyeseetea.malariacare.domain.service.CompetencyScoreCalculationDomainService.NON_CRITICAL_COMPETENT_NEEDS_IMPROVEMENT_SCORE_LIMIT;
 import static org.eyeseetea.malariacare.domain.service.CompetencyScoreCalculationDomainService.NON_CRITICAL_COMPETENT_SCORE_LIMIT;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import static org.hamcrest.CoreMatchers.is;
 
 public class CompetencyScoreCalculationDomainServiceShould {
 
@@ -22,7 +21,7 @@ public class CompetencyScoreCalculationDomainServiceShould {
     @Test
     public void return_not_competent_if_has_critical_steps_missed() {
         CompetencyScoreClassification classification =
-                domainService.calculateClassification(true, 100f);
+                domainService.calculateClassification(true, 100f, false);
 
         assertThat(classification, is(CompetencyScoreClassification.NOT_COMPETENT));
     }
@@ -31,7 +30,7 @@ public class CompetencyScoreCalculationDomainServiceShould {
     public void return_not_competent_if_has_not_critical_steps_missed_and_non_critical_score_is_lower_than_cni_limit() {
         CompetencyScoreClassification classification =
                 domainService.calculateClassification(false,
-                        NON_CRITICAL_COMPETENT_NEEDS_IMPROVEMENT_SCORE_LIMIT - 1);
+                        NON_CRITICAL_COMPETENT_NEEDS_IMPROVEMENT_SCORE_LIMIT - 1, false);
 
         assertThat(classification, is(CompetencyScoreClassification.NOT_COMPETENT));
     }
@@ -40,7 +39,7 @@ public class CompetencyScoreCalculationDomainServiceShould {
     public void return_cni_if_has_not_critical_steps_missed_and_non_critical_score_is_lower_than_c_limit() {
         CompetencyScoreClassification classification =
                 domainService.calculateClassification(false,
-                        NON_CRITICAL_COMPETENT_SCORE_LIMIT - 1);
+                        NON_CRITICAL_COMPETENT_SCORE_LIMIT - 1, false);
 
         assertThat(classification, is(CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT));
     }
@@ -49,7 +48,7 @@ public class CompetencyScoreCalculationDomainServiceShould {
     public void return_cni_if_has_not_critical_steps_missed_and_non_critical_score_is_greater_than_cni_limit() {
         CompetencyScoreClassification classification =
                 domainService.calculateClassification(false,
-                        NON_CRITICAL_COMPETENT_NEEDS_IMPROVEMENT_SCORE_LIMIT + 1);
+                        NON_CRITICAL_COMPETENT_NEEDS_IMPROVEMENT_SCORE_LIMIT + 1, false);
 
         assertThat(classification, is(CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT));
     }
@@ -59,7 +58,15 @@ public class CompetencyScoreCalculationDomainServiceShould {
         CompetencyScoreClassification classification =
                 domainService.calculateClassification(false,
                         NON_CRITICAL_COMPETENT_SCORE_LIMIT
-                                + 1);
+                                + 1, false);
+
+        assertThat(classification, is(CompetencyScoreClassification.COMPETENT));
+    }
+
+    @Test
+    public void return_competent_if_has_not_critical_steps_missed_and_any_non_critical_steps_are_answered() {
+        CompetencyScoreClassification classification =
+                domainService.calculateClassification(false, 0.0f, true);
 
         assertThat(classification, is(CompetencyScoreClassification.COMPETENT));
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2404  
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance/changes_in_competency_classes Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Apply changes in competency classes

All critical steps and (≥ 89.9% non-critical steps correct OR NONE OF THE NON-CRITICAL STEPS ANSWERED) = Competent
All critical steps correct and between 79.9% and < 89.9% non-critical steps correct = Competent but needs improvement
Any critical step missed and below 79.9% of non-critical steps correct = Not competent

### :memo: How is it being implemented?

I have modified competency limit percentages
I have created a new function in questiondb to return answered questions by survey and critical or non-critical 
I have modified logic to calculate competency classes

### :boom: How can it be tested?

Scenarios reporting by client:
https://docs.google.com/spreadsheets/d/1rjm-M70tWPRQY5D3YH2aIwNdnJdrt_dJEpViwB7B_lk/edit#gid=968668474

All scenarios:
https://drive.google.com/file/d/1KNNdfn0XBvrPAKHL7s4b_iGLxi_TI00S/view?usp=sharing

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
