### PR TITLE
Fix some bugs moving between tabs and to change filters

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorBySurveyActionsFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorBySurveyActionsFragment.java
@@ -6,7 +6,6 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 import android.widget.ProgressBar;
 
 import org.eyeseetea.malariacare.DashboardActivity;
@@ -58,21 +57,28 @@ public class MonitorBySurveyActionsFragment extends FiltersFragment implements
     }
 
     @Override
-    public void onDestroy() {
+    public void onPause() {
         presenter.detachView();
-        super.onDestroy();
+        super.onPause();
     }
 
     @Override
     protected void onFiltersChanged() {
-        DashboardActivity.dashboardActivity.openMonitoringByCalendar();
+        if (existFilter()) {
+            DashboardActivity.dashboardActivity.openMonitoringByCalendar();
+        }
+    }
+
+    private boolean existFilter() {
+        return !selectedProgramUidFilter.isEmpty() || !selectedOrgUnitUidFilter.isEmpty();
     }
 
 
     @Override
     public void reloadData() {
         super.reloadData();
-        if (presenter != null){
+
+        if (presenter != null && !existFilter()) {
             presenter.refresh(selectedProgramUidFilter, selectedOrgUnitUidFilter);
         }
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorFragment.java
@@ -92,7 +92,6 @@ public class MonitorFragment extends Fragment implements IModuleFragment {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.d(TAG, "onCreate");
         super.onCreate(savedInstanceState);
     }
 
@@ -173,7 +172,6 @@ public class MonitorFragment extends Fragment implements IModuleFragment {
 
     @Override
     public void onStop() {
-        Log.d(TAG, "onStop");
         unregisterSurveysReceiver();
         stopMonitor();
         super.onStop();
@@ -181,7 +179,6 @@ public class MonitorFragment extends Fragment implements IModuleFragment {
 
     @Override
     public void onPause() {
-        Log.d(TAG, "onPause");
         unregisterSurveysReceiver();
 
         super.onPause();

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/ImproveModuleController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/ImproveModuleController.java
@@ -158,7 +158,7 @@ public class ImproveModuleController extends ModuleController {
         //Reload improve fragment
         if (DashboardOrientation.VERTICAL.equals(dashboardController.getOrientation())) {
             dashboardController.reloadVertical();
-        } else if (fragment instanceof FeedbackFragment) {
+        } else if (fragment instanceof FeedbackFragment || fragment instanceof ObservationsFragment) {
             reloadFragment();
         }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/OrgUnitProgramFilterPresenter.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/OrgUnitProgramFilterPresenter.kt
@@ -43,7 +43,7 @@ class OrgUnitProgramFilterPresenter(
         if (selectedProgramName != programName) {
             changeSelectedProgram(programName)
 
-            if (exclusiveFilter) {
+            if (exclusiveFilter ) {
                 unSelectOrgUnit()
             }
 
@@ -78,7 +78,13 @@ class OrgUnitProgramFilterPresenter(
         val orgUnitNameToSelect = orgUnitToSelect?.name ?: allOrgUnitText
 
         onProgramSelected(programNameToSelect)
-        onOrgUnitSelected(orgUnitNameToSelect)
+
+        if (exclusiveFilter ) {
+            unSelectOrgUnit()
+            notifyOrgUnitFilterChange()
+        }else{
+            onOrgUnitSelected(orgUnitNameToSelect)
+        }
 
         notifySelectOrgUnit()
         notifySelectProgram()

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/OrgUnitProgramFilterPresenter.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/OrgUnitProgramFilterPresenter.kt
@@ -43,7 +43,7 @@ class OrgUnitProgramFilterPresenter(
         if (selectedProgramName != programName) {
             changeSelectedProgram(programName)
 
-            if (exclusiveFilter ) {
+            if (exclusiveFilter) {
                 unSelectOrgUnit()
             }
 
@@ -79,10 +79,10 @@ class OrgUnitProgramFilterPresenter(
 
         onProgramSelected(programNameToSelect)
 
-        if (exclusiveFilter ) {
+        if (exclusiveFilter) {
             unSelectOrgUnit()
             notifyOrgUnitFilterChange()
-        }else{
+        } else {
             onOrgUnitSelected(orgUnitNameToSelect)
         }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2407   
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance/fix_bugs_moving_from_improve_to_monitor_and_changing_filters Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Description
--
Moving from action plan to monitor module have one of the following behaviors:
1. The screen turns black and the app asks to be closed
2. Shows the screen with the Total number of surveys undertaken
3. Correctly populates the monitor module screen with the specific filter (by survey or by Org Unit)
server:https://clone.psi-mis.org/User:KEdemo1

### :memo: How is it being implemented?

- I have changed when the view is detached in presenter from onDestroy to onPause
- I have fixed some bugs in OrgUnitProgramFilterPresenter

### :boom: How can it be tested?

How to replicate
--
In the improve module select any survey and go to the action plan go to the monitor moduleRepeat these steps with different surveys to have the different behaviours

Video
--
Link to video here.
https://drive.google.com/file/d/1JFlYJCiM18A3H_u2OqDL9wj7DY2peAAh/view?usp=sharing

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-