### PR TITLE
Only refresh current tab after push if it's improve

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/DashboardController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/DashboardController.java
@@ -148,7 +148,7 @@ public class DashboardController {
     /**
      * Returns the module in charge of the currently selected tab
      */
-    private ModuleController getCurrentModule() {
+    public ModuleController getCurrentModule() {
         if (currentTab == null) {
             return null;
         }

--- a/app/src/main/java/org/eyeseetea/malariacare/receivers/AlarmPushReceiver.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/receivers/AlarmPushReceiver.java
@@ -29,6 +29,8 @@ import android.util.Log;
 
 import org.eyeseetea.malariacare.DashboardActivity;
 import org.eyeseetea.malariacare.data.database.iomodules.dhis.exporter.PushDataController;
+import org.eyeseetea.malariacare.layout.dashboard.controllers.DashboardController;
+import org.eyeseetea.malariacare.layout.dashboard.controllers.ImproveModuleController;
 import org.eyeseetea.malariacare.observables.ObservablePush;
 import org.eyeseetea.malariacare.services.PushService;
 import org.eyeseetea.malariacare.services.SurveyService;
@@ -54,9 +56,14 @@ public class AlarmPushReceiver extends BroadcastReceiver {
     public static void isDoneSuccess(PushDataController.Kind kind) {
         Log.i(TAG, "isDoneSuccess");
         setFail(false);
-        if(kind.equals(PushDataController.Kind.EVENTS)) {
+
+        DashboardController dashboardController =
+                DashboardActivity.dashboardActivity.dashboardController;
+
+        if (kind.equals(PushDataController.Kind.EVENTS) &&
+                dashboardController.getCurrentModule() instanceof ImproveModuleController) {
             DashboardActivity.dashboardActivity.reloadActiveTab();
-        }else {
+        } else {
             ObservablePush.getInstance().pushFinish();
         }
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2409  
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance/push_takes_out_the_user_from_in_progress_survey Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Avoid takes out the user from in-progress survey after success push.

### :memo: How is it being implemented?

In AlarmPushReceiver only refresh current tab if is improve 

### :boom: How can it be tested?

**use case 1:** create a new survey and sent list should refresh after push
**use case 2:** create a new survey and to start to create another survey. The app should not take out the user from the in-progress survey after success push.
**use case 3:** start to create another survey. The app should not take out the user from the in-progress survey after not found surveys push.

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
