### PR TITLE
Rename bubble monitor label

### DIFF
--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -191,7 +191,7 @@ clínica"</string>
 <string name="error_message_push">"El evento con UID: %s. fue subido sin fecha. Por favor, póngase en contacto con el administrador. "</string>
 <string name="monitor_js_assessments" >Encuestas realizadas</string>
 <string name="monitor_js_target" >"Objetivo"</string>
-<string name="monitor_js_quality_of_care" >"Calidad de cuidados: Últimos "</string>
+<string name="monitor_js_quality_of_care" >"Clases de competencia - "</string>
 <string name="monitor_js_months" >" meses"</string>
 <string name="monitor_js_multiple_event_legend" >"(*)Hay más de una encuesta en el mismo mes"</string>
 

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -188,7 +188,7 @@ Mensuelle"</string>
 <string name="error_message_push">"L'événement avec identifiant : %s. a été envoyé sans sa date. S'il vous plaît contactez l'administrateur."</string>
 <string name="monitor_js_assessments">"Enquêtes réalisés"</string>
 <string name="monitor_js_target">"Objectif"</string>
-<string name="monitor_js_quality_of_care">"Qualité des soins: Dernier "</string>
+<string name="monitor_js_quality_of_care">"Classes de compétence -"</string>
 <string name="monitor_js_months">" mois"</string>
 <string name="monitor_js_multiple_event_legend" >"(*) Plus d'une enquête existe le même mois"</string>
 

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -202,7 +202,7 @@
 <string name="error_message_push">"ព្រឹត្តិការណ៍នេះជាមួយនឹងលេខសម្គាល់អ្នកប្រើ %s ។ ត្រូវបានផ្ទុកឡើងដោយគ្មានកាលបរិច្ឆេទ។ សូមទាក់ទងអ្នកគ្រប់គ្រង។"</string>
 <string name="monitor_js_assessments">"ការស្ទង់មតិធ្វើឡើង"</string>
 <string name="monitor_js_target">"\"គោលដៅ\""</string>
-<string name="monitor_js_quality_of_care">"\"គុណភាពនៃការថែទាំ: មុន \""</string>
+<string name="monitor_js_quality_of_care">"ថ្នាក់សមត្ថភាព -"</string>
 <string name="monitor_js_months">"\" ខែ\""</string>
 <string name="monitor_js_multiple_event_legend" >"(*) ការស្ទង់មតិច្រើនជាងមួយមាននៅក្នុងខែដដែល"</string>
 <string name="dialog_error_attribute_null">"\"លេខសម្គាល់គុណលក្ខណៈជាមួយ NULL% s សូមទាក់ទងអ្នកគ្រប់គ្រងម៉ាស៊ីនបម្រើរបស់អ្នក.\""</string>

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -199,7 +199,7 @@
 <string name="error_message_push">"ຂໍ້ມູນສຳຫຼວດທີ່ມີລະຫັດ UID: %s ນີ້, ຖືກໂຫຼດເຂົ້າໃສ່ລະບົບໂດຍບໍ່ມີວັນທີ. ກະລຸນາຕິດຕໍ່ຫາຜູ້ຄວບຄຸມລະບົບ."</string>
 <string name="monitor_js_assessments">"ການສໍາຫຼວດປະຕິບັດ"</string>
 <string name="monitor_js_target">"ເປົ້າໝາຍ"</string>
-<string name="monitor_js_quality_of_care">"ຄຸນນະພາບຂອງການບໍລິການ: .....ຜ່ານມາ"</string>
+<string name="monitor_js_quality_of_care">"ຫ້ອງຮຽນຄວາມສາມາດ - "</string>
 <string name="monitor_js_months">"...ເດືອນ"</string>
 <string name="monitor_js_multiple_event_legend" >"(*) ມີການສໍາຫຼວດຫຼາຍກວ່າຫນຶ່ງເດືອນໃນເດືອນດຽວກັນ"</string>
 <string name="dialog_error_attribute_null">"\" ຂໍ້ມູນຂອງ id %s ນີ້ບໍ່ມີ. ກະລຸນາຕິດຫາຜູ້ຄວບຄຸມລະບົບ\""</string>

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -190,7 +190,7 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="error_message_push">"O evento com UID: %s. foi carregado sem data. Entre em contato com o administrador."</string>
 <string name="monitor_js_assessments" >"Inquéritos realizados"</string>
 <string name="monitor_js_target" >"Objetivo"</string>
-<string name="monitor_js_quality_of_care" >"A qualidade do atendimento: Últimos"</string>
+<string name="monitor_js_quality_of_care" >"Classes de competência - "</string>
 <string name="monitor_js_months" >" meses"</string>
 <string name="monitor_js_multiple_event_legend" >"(*) Mais de uma pesquisa existe no mesmo mês"</string>
 <string name="create">Crio</string>

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -192,7 +192,7 @@ evaluation"</string>
 <string name="error_message_push">"The event with UID: %s. was uploaded without date. Please contact the administrator. "</string>
 <string name="monitor_js_assessments">"Surveys undertaken"</string>
 <string name="monitor_js_target">"Target"</string>
-<string name="monitor_js_quality_of_care">"Quality of care: Last "</string>
+<string name="monitor_js_quality_of_care">"Competency Classes -"</string>
 <string name="monitor_js_months">" months"</string>
 <string name="monitor_js_multiple_event_legend" >"(*)More than one survey exist in the same month"</string>
 

--- a/app/src/main/assets/dashboard/translated.messages.js
+++ b/app/src/main/assets/dashboard/translated.messages.js
@@ -14,7 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 var messages= {
     "assesmentUnderTaken":"Assessment undertaken",
     "target": "Target",
-    "qualityOfCare": "Quality of care: Last ",
+    "qualityOfCare": "Competency Classes - ",
     "months": " months",
     "noSurveys": "No surveys to show",
     "multipleEventLegend": "(*)More than one survey exist on the same month"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -188,7 +188,7 @@ clínica"</string>
 <string name="error_message_push">"El evento con UID: %s. fue subido sin fecha. Por favor, póngase en contacto con el administrador. "</string>
 <string name="monitor_js_assessments" >Encuestas realizadas</string>
 <string name="monitor_js_target" >"Objetivo"</string>
-<string name="monitor_js_quality_of_care" >"Calidad de cuidados: Últimos "</string>
+<string name="monitor_js_quality_of_care" >"lases de competencia - "</string>
 <string name="monitor_js_months" >" meses"</string>
 
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -185,7 +185,7 @@ Mensuelle"</string>
 <string name="error_message_push">"L'événement avec identifiant : %s. a été envoyé sans sa date. S'il vous plaît contactez l'administrateur."</string>
 <string name="monitor_js_assessments">"Rapports réalisés"</string>
 <string name="monitor_js_target">"Objectif"</string>
-<string name="monitor_js_quality_of_care">"Qualité des soins: Dernier "</string>
+<string name="monitor_js_quality_of_care">"Classes de compétence -"</string>
 <string name="monitor_js_months">" mois"</string>
 
 <string name="create">"Créer"</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -197,7 +197,7 @@ evaluation"</string>
 <string name="error_message_push">"ព្រឹត្តិការណ៍នេះជាមួយនឹងលេខសម្គាល់អ្នកប្រើ %s ។ ត្រូវបានផ្ទុកឡើងដោយគ្មានកាលបរិច្ឆេទ។ សូមទាក់ទងអ្នកគ្រប់គ្រង។"</string>
 <string name="monitor_js_assessments">"ការវាយតម្លៃអនុវត្ត"</string>
 <string name="monitor_js_target">"\"គោលដៅ\""</string>
-<string name="monitor_js_quality_of_care">"\"គុណភាពនៃការថែទាំ: មុន \""</string>
+<string name="monitor_js_quality_of_care">"ថ្នាក់សមត្ថភាព -"</string>
 <string name="monitor_js_months">"\" ខែ\""</string>
 <string name="dialog_error_attribute_null">"\"លេខសម្គាល់គុណលក្ខណៈជាមួយ NULL% s សូមទាក់ទងអ្នកគ្រប់គ្រងម៉ាស៊ីនបម្រើរបស់អ្នក.\""</string>
 <string name="progress_pull_relationships">"កសាងទំនាក់ទំនងសំណួរ ..."</string>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -198,7 +198,7 @@
 <string name="error_message_push">"ຂໍ້ມູນສຳຫຼວດທີ່ມີລະຫັດ UID: %s ນີ້, ຖືກໂຫຼດເຂົ້າໃສ່ລະບົບໂດຍບໍ່ມີວັນທີ. ກະລຸນາຕິດຕໍ່ຫາຜູ້ຄວບຄຸມລະບົບ."</string>
 <string name="monitor_js_assessments">"ການປະເມີນທີ່ກຳລັງດຳເນີດການ"</string>
 <string name="monitor_js_target">"ເປົ້າໝາຍ"</string>
-<string name="monitor_js_quality_of_care">"ຄຸນນະພາບຂອງການບໍລິການ: ຜ່ານມາ"</string>
+<string name="monitor_js_quality_of_care">"ຫ້ອງຮຽນຄວາມສາມາດ - "</string>
 <string name="monitor_js_months">"ເດຶອນ"</string>
 <string name="dialog_error_attribute_null">"\" ຂໍ້ມູນຂອງ id %s ນີ້ບໍ່ມີ. ກະລຸນາຕິດຫາຜູ້ຄວບຄຸມລະບົບ\""</string>
 <string name="progress_pull_relationships">"ການສ້າງຄວາມເຊື່ອມໂຍງຂອງຄຳຖາມ"</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -187,7 +187,7 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="error_message_push">"O evento com UID: %s. foi carregado sem data. Entre em contato com o administrador."</string>
 <string name="monitor_js_assessments" >"Avaliações realizadas"</string>
 <string name="monitor_js_target" >"Objetivo"</string>
-<string name="monitor_js_quality_of_care" >"A qualidade do atendimento: Ultimos"</string>
+<string name="monitor_js_quality_of_care" >"Classes de competência - "</string>
 <string name="monitor_js_months" >" meses"</string>
 <string name="create">Crio</string>
 <string name="modify">Modificar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,7 +189,7 @@ evaluation"</string>
 <string name="error_message_push">"The event with UID: %s. was uploaded without date. Please contact the administrator. "</string>
 <string name="monitor_js_assessments">"Assessments undertaken"</string>
 <string name="monitor_js_target">"Target"</string>
-<string name="monitor_js_quality_of_care">"Quality of care: Last "</string>
+<string name="monitor_js_quality_of_care">"Competency Classes -"</string>
 <string name="monitor_js_months">" months"</string>
 
 <string name="create">"Create"</string>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2411   
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature/rename_label_in_bubble_monitoring Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Currently, the label of the Scores Chart Dashboard in the Monitor Module is stated as Quality of Care.
It has been requested to change it to: "Competency class" , to be aligned with the new classification schema.
We have also noticed that the label reports 'Last 6 months' when it's actually Last 5 months + Current month. Since you are changing the label, I suggest changing it to 'Competency Classes - 6 months'.

### :memo: How is it being implemented?

I have renamed strings

### :boom: How can it be tested?

**use case 1:** Open app filter by org unit or program and navigate to monitor

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
