### PR TITLE
Remove monitoring target settings

### DIFF
--- a/app/src/hnqis/res/values-es/strings.xml
+++ b/app/src/hnqis/res/values-es/strings.xml
@@ -143,7 +143,6 @@ clínica"</string>
 <string name="server_url">"Servidor DHIS2"</string>
 <string name="settings_text_dhis_password">"Contraseña DHIS"</string>
 <string name="settings_text_dhis_max_items">"DHIS max encuestas descargadas"</string>
-<string name="settings_monitoring_target">"Objetivo de monitorización"</string>
 <string name="dialog_error_push_uids">"UIDs incorrectos encontrados en el envio"</string>
 <string name="dialog_error_push_no_location_and_required">"Localización no disponible y es un campo obligatorio"</string>
 <string name="dialog_error_attribute_null">"El atributo con id %s es null, por favor, póngase en contacto con el administrador del servidor."</string>

--- a/app/src/hnqis/res/values-fr/strings.xml
+++ b/app/src/hnqis/res/values-fr/strings.xml
@@ -141,7 +141,6 @@ Mensuelle"</string>
 <string name="server_url">"Serveur DHIS2"</string>
 <string name="settings_text_dhis_password">"Mot de passe DHIS2"</string>
 <string name="settings_text_dhis_max_items">"Nombre max de rapports DHIS2 téléchargés"</string>
-<string name="settings_monitoring_target">"Objectif de surveillance"</string>
 <string name="dialog_error_push_uids">"Identifiant incorrect pour l'envoi"</string>
 <string name="dialog_error_push_no_location_and_required">"Aucune localisation disponible et c'est un champ obligatoire"</string>
 <string name="dialog_error_attribute_null">"Attribut avec id %s est nulle, s'il vous plaît contacter votre admin serveur."</string>

--- a/app/src/hnqis/res/values-km/strings.xml
+++ b/app/src/hnqis/res/values-km/strings.xml
@@ -159,7 +159,6 @@
 <string name="server_url">"DHIS2 server"</string>
 <string name="settings_text_dhis_password">"ពាក្យសម្ងាត់ DHIS"</string>
 <string name="settings_text_dhis_max_items">"DHIS អតិបរមាការស្ទង់មតិបានផ្ទុក"</string>
-<string name="settings_monitoring_target">"គោលដៅតាមដាន"</string>
 <string name="dialog_error_push_uids">"UID ដែលមិនត្រឹមត្រូវបានរកឃើញក្នុងការរុញ"</string>
 <string name="dialog_error_push_no_location_and_required">"គ្មានទីតាំងដែលអាចប្រើបានទេហើយវាជាវាលចាំបាច់"</string>
 <string name="dialog_info_push_imported">"បាននាំចូល"</string>

--- a/app/src/hnqis/res/values-lo/strings.xml
+++ b/app/src/hnqis/res/values-lo/strings.xml
@@ -156,7 +156,6 @@
 <string name="server_url">"ເຊີເວີຂອງລະບົບ DHIS"</string>
 <string name="settings_text_dhis_password">"ລະຫັດຜ່ານເຂົ້ານຳໃຊ້ລະບົບ DHIS"</string>
 <string name="settings_text_dhis_max_items">"ຈຳນວນຫຼາຍສຸດຂອງຂໍ້ມູນທີ່ລະບົບ dhis ສາມາດຮອງຮັບໄດ້"</string>
-<string name="settings_monitoring_target">"ເປົ້າຫມາຍການຕິດຕາມ"</string>
 <string name="dialog_error_push_uids">"ລະຫັດ  UIDs  ບໍ່ຖືກ "</string>
 <string name="dialog_error_push_no_location_and_required">"ຈຸດທີ່ຕັ້ງບໍ່ເຫັນ, ກະລຸນາຕືມຂໍ້ມູນໃສ່"</string>
 <string name="dialog_info_push_imported">"ນຳເຂົ້າ"</string>

--- a/app/src/hnqis/res/values-pt/strings.xml
+++ b/app/src/hnqis/res/values-pt/strings.xml
@@ -143,7 +143,6 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="server_url">"Servidor DHIS2"</string>
 <string name="settings_text_dhis_password">"Senha DHIS"</string>
 <string name="settings_text_dhis_max_items">"DHIS max carregado inquéritos"</string>
-<string name="settings_monitoring_target">"Alvo de monitoramento"</string>
 <string name="dialog_error_push_uids">"UIDs incorretas encontradas no impulso"</string>
 <string name="dialog_error_push_no_location_and_required">"Nenhum local disponível e é um campo obrigatório"</string>
 <string name="dialog_error_attribute_null">"Atributo com id %s é nulo, por favor contacte o seu administrador do servidor."</string>

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -144,7 +144,6 @@ evaluation"</string>
 <string name="server_url">"DHIS2 server"</string>
 <string name="settings_text_dhis_password">"DHIS password"</string>
 <string name="settings_text_dhis_max_items">"DHIS max loaded surveys"</string>
-<string name="settings_monitoring_target">"Monitoring target"</string>
 <string name="dialog_error_push_uids">"Incorrect UIDs found in push"</string>
 <string name="dialog_error_push_no_location_and_required">"No location available and it is a required field"</string>
 <string name="dialog_error_attribute_null">\"Attribute with id %s null, please contact your server admin.\"</string>

--- a/app/src/main/java/org/eyeseetea/malariacare/SettingsActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/SettingsActivity.java
@@ -240,8 +240,6 @@ public class SettingsActivity extends AppCompatActivity implements
                     findPreference(getActivity().getString(R.string.font_sizes)));
             bindPreferenceSummaryToValue(findPreference(getString(R.string.dhis_max_items)));
 
-            bindPreferenceSummaryToValue(findPreference(getString(R.string.monitoring_target)));
-
             Preference serverUrlPreference = findPreference(
                     getResources().getString(R.string.dhis_url));
             Preference userPreference = findPreference(

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
@@ -129,13 +129,12 @@ public class PreferencesState {
         locationRequired = initLocationRequired();
         hidePlanningTab = initHidePlanningTab();
         maxEvents = initMaxEvents();
-        monitoringTarget = initMonitoringTarget();
         languageCode = initLanguageCode();
         userAccept = initUserAccept();
         Log.d(TAG, String.format(
                 "reloadPreferences: scale: %s | locationRequired: %b | "
-                        + "maxEvents: %d | largeTextOption: %b  | target: %d",
-                scale, locationRequired, maxEvents, showLargeText, monitoringTarget));
+                        + "maxEvents: %d | largeTextOption: %b",
+                scale, locationRequired, maxEvents, showLargeText));
 
         creedentials = initCredentials();
     }
@@ -245,18 +244,6 @@ public class PreferencesState {
     }
 
     /**
-     * Inits target settings
-     */
-    private int initMonitoringTarget() {
-        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
-                instance.getContext());
-        String maxValue = sharedPreferences.getString(
-                instance.getContext().getString(R.string.monitoring_target),
-                instance.getContext().getString(R.string.default_monitoring_target));
-        return Integer.valueOf(maxValue);
-    }
-
-    /**
      * Inits maps of dimensions
      */
     private Map<String, Map<String, Float>> initScaleDimensionsMap() {
@@ -335,11 +322,11 @@ public class PreferencesState {
     }
 
     public int getMonitoringTarget() {
-        return monitoringTarget;
-    }
-
-    public void setMonitoringTarget(int monitoringTarget) {
-        this.monitoringTarget = monitoringTarget;
+        // TODO: The monitoring target preference is removed because is used by old monitoring
+        //  without filters that It's not visible any more. But since the old monitoring code
+        //  is still present reading from this getter, we leave the getter returning
+        //  always default value. When the old monitoring code is removed, delete this getter.
+        return Integer.valueOf(instance.getContext().getString(R.string.default_monitoring_target));
     }
 
     public Float getFontSize(String scale, String dimension) {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -140,7 +140,6 @@ clínica"</string>
 <string name="server_url">"Servidor DHIS2"</string>
 <string name="settings_text_dhis_password">"Contraseña DHIS"</string>
 <string name="settings_text_dhis_max_items">"DHIS max encuestas descargadas"</string>
-<string name="settings_monitoring_target">"Objetivo de monitorización"</string>
 <string name="dialog_error_push_uids">"UIDs incorrectos encontrados en el envio"</string>
 <string name="dialog_error_push_no_location_and_required">"Localización no disponible y es un campo obligatorio"</string>
 <string name="dialog_error_attribute_null">"El atributo con id %s es null, por favor, póngase en contacto con el administrador del servidor."</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -138,7 +138,6 @@ Mensuelle"</string>
 <string name="server_url">"Serveur DHIS2"</string>
 <string name="settings_text_dhis_password">"Mot de passe DHIS2"</string>
 <string name="settings_text_dhis_max_items">"Nombre max de rapports DHIS2 téléchargés"</string>
-<string name="settings_monitoring_target">"Objectif de surveillance"</string>
 <string name="dialog_error_push_uids">"Identifiant incorrect pour l'envoi"</string>
 <string name="dialog_error_push_no_location_and_required">"Aucune localisation disponible et c'est un champ obligatoire"</string>
 <string name="dialog_error_attribute_null">"Attribut avec id %s est nulle, s'il vous plaît contacter votre admin serveur."</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -154,7 +154,6 @@ evaluation"</string>
 <string name="server_url">"DHIS2 server"</string>
 <string name="settings_text_dhis_password">"DHIS password"</string>
 <string name="settings_text_dhis_max_items">"DHIS max loaded surveys"</string>
-<string name="settings_monitoring_target">"គោលដៅតាមដាន"</string>
 <string name="dialog_error_push_uids">"Incorrect UIDs found in push"</string>
 <string name="dialog_error_push_no_location_and_required">"No location available and it is a required field"</string>
 <string name="dialog_info_push_imported">"Imported"</string>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -155,7 +155,6 @@
 <string name="server_url">"ເຊີເວີຂອງລະບົບ DHIS"</string>
 <string name="settings_text_dhis_password">"ລະຫັດຜ່ານເຂົ້ານຳໃຊ້ລະບົບ DHIS"</string>
 <string name="settings_text_dhis_max_items">"ຈຳນວນຫຼາຍສຸດຂອງຂໍ້ມູນທີ່ລະບົບ dhis ສາມາດຮອງຮັບໄດ້"</string>
-<string name="settings_monitoring_target">"ເປົ້າຫມາຍການຕິດຕາມ"</string>
 <string name="dialog_error_push_uids">"ລະຫັດ  UIDs  ບໍ່ຖືກ "</string>
 <string name="dialog_error_push_no_location_and_required">"ຈຸດທີ່ຕັ້ງບໍ່ເຫັນ, ກະລຸນາຕືມຂໍ້ມູນໃສ່"</string>
 <string name="dialog_info_push_imported">"ນຳເຂົ້າ"</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -151,7 +151,6 @@
 <string name="server_url"></string>
 <string name="settings_text_dhis_password"></string>
 <string name="settings_text_dhis_max_items"></string>
-<string name="settings_monitoring_target"></string>
 <string name="dialog_error_push_uids"></string>
 <string name="dialog_error_push_no_location_and_required"></string>
 <string name="dialog_error_attribute_null"></string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -140,7 +140,6 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="server_url">"Servidor DHIS2"</string>
 <string name="settings_text_dhis_password">"Senha DHIS"</string>
 <string name="settings_text_dhis_max_items">"DHIS max carregado inquéritos"</string>
-<string name="settings_monitoring_target">"Alvo de monitoramento"</string>
 <string name="dialog_error_push_uids">"UIDs incorretas encontradas no impulso"</string>
 <string name="dialog_error_push_no_location_and_required">"Nenhum local disponível e é um campo obrigatório"</string>
 <string name="dialog_error_attribute_null">"Atributo com id %s é nulo, por favor contacte o seu administrador do servidor."</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -46,7 +46,6 @@
     <string name="dhis_password" translatable="false">dhis_password</string>
     <string name="dhis_max_items" translatable="false">dhis_max_items</string>
     <string name="dhis_default_max_items" translatable="false">30</string>
-    <string name="monitoring_target" translatable="false">monitoring_target</string>
     <string name="default_monitoring_target" translatable="false">30</string>
     <string name="location_required" translatable="false">location_required</string>
     <string name="pull_metadata" translatable="false">pull_metadata</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,7 +141,6 @@ evaluation"</string>
 <string name="server_url">"DHIS2 server"</string>
 <string name="settings_text_dhis_password">"DHIS password"</string>
 <string name="settings_text_dhis_max_items">"DHIS max loaded surveys"</string>
-<string name="settings_monitoring_target">"Monitoring target"</string>
 <string name="dialog_error_push_uids">"Incorrect UIDs found in push"</string>
 <string name="dialog_error_push_no_location_and_required">"No location available and it is a required field"</string>
 <string name="dialog_error_attribute_null">\"Attribute with id %s null, please contact your server admin.\"</string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -93,18 +93,6 @@
         android:maxLength="4"
         app:iconSpaceReserved="false"/>
 
-    <android.support.v7.preference.EditTextPreference
-        android:key="@string/monitoring_target"
-        android:title="@string/settings_monitoring_target"
-        android:defaultValue="@string/default_monitoring_target"
-        android:selectAllOnFocus="true"
-        android:inputType="number"
-        android:numeric="integer"
-        android:singleLine="true"
-        android:maxLines="1"
-        android:maxLength="4"
-        app:iconSpaceReserved="false"/>
-
     <android.support.v7.preference.CheckBoxPreference
         android:key="@string/hide_planning_tab_key"
         android:title="@string/hide_planning_tab_title"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2413   
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature/remove_monitoring_target_from_settings Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Remove monitoring target settings

### :memo: How is it being implemented?

I have removed preference, strings and I have left getMonitoringTarget getter in PreferenceState.

I have added this TODO comment in PreferenceState getter :
The monitoring target preference is removed because is used by old monitoring
without filters that It's not visible any more. But since the old monitoring code
is still present reading from this getter, we leave the getter returning
always default value. When the old monitoring code is removed, delete this getter.

### :boom: How can it be tested?

**use case 1:** Open the app then preference monitoring target should no be visible in settings activity and monitoring should work.

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
