### PR TITLE
Fix bug when sometimes filter by org unit from monitor by actions

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/OrgUnitProgramFilterPresenter.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/OrgUnitProgramFilterPresenter.kt
@@ -79,7 +79,7 @@ class OrgUnitProgramFilterPresenter(
 
         onProgramSelected(programNameToSelect)
 
-        if (exclusiveFilter) {
+        if (exclusiveFilter && programToSelect != null && orgUnitToSelect != null) {
             unSelectOrgUnit()
             notifyOrgUnitFilterChange()
         } else {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2415   
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: fix/filter_in_monitoring_by_org_unit Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Fix bug related to org unit filter from the monitor by actions fragment

### :memo: How is it being implemented?

After many time reviewing tabs, filters, module controllers the problem was in the filters presenter. When is loaded and it's exclusive only should unselect org unit filter if program and org unit filter is selected but if only org unit filter is selected has no sense unselect it

### :boom: How can it be tested?

Steps to reproduce [here](https://github.com/EyeSeeTea/QAApp/issues/360)

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
