### PR TITLE
Change next assessment logic to competencies or scoring

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
@@ -124,13 +124,13 @@ public class LoginActivity extends Activity implements LoginPresenter.View {
                 && sharedPreferences.getBoolean(
                 getApplicationContext().getResources().getString(R.string.pull_metadata), false)) {
             launchActivity(LoginActivity.this, DashboardActivity.class);
+        } else {
+            ProgressActivity.PULL_CANCEL = false;
+
+            initViews();
+            initPresenter();
+            initServerAdapter();
         }
-
-        ProgressActivity.PULL_CANCEL = false;
-
-        initViews();
-        initPresenter();
-        initServerAdapter();
     }
 
     private void initViews() {

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -31,6 +31,7 @@ import org.eyeseetea.malariacare.data.database.model.CompositeScoreDB;
 import org.eyeseetea.malariacare.data.database.model.ObservationDB;
 import org.eyeseetea.malariacare.data.database.model.ObservationValueDB;
 import org.eyeseetea.malariacare.data.database.model.OrgUnitProgramRelationDB;
+import org.eyeseetea.malariacare.data.database.model.ServerDB;
 import org.eyeseetea.malariacare.data.database.model.ServerMetadataDB;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.model.UserDB;
@@ -43,6 +44,7 @@ import org.eyeseetea.malariacare.domain.boundary.IPushController;
 import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 import org.eyeseetea.malariacare.domain.entity.NextScheduleDateConfiguration;
 import org.eyeseetea.malariacare.domain.entity.ScoreType;
+import org.eyeseetea.malariacare.domain.entity.ServerClassification;
 import org.eyeseetea.malariacare.domain.entity.pushsummary.PushConflict;
 import org.eyeseetea.malariacare.domain.entity.pushsummary.PushReport;
 import org.eyeseetea.malariacare.domain.exception.ConversionException;
@@ -546,11 +548,15 @@ public class ConvertToSDKVisitor implements
         SurveyNextScheduleDomainService surveyNextScheduleDomainService = new
                 SurveyNextScheduleDomainService();
 
+        ServerDB serverDB = ServerDB.getConnectedServerFromDB();
+
         Date nextScheduleDate = surveyNextScheduleDomainService.calculate(
                 nextScheduleDateConfiguration,
                 eventDate,
                 competencyScoreClassification,
-                survey.isLowProductivity());
+                survey.isLowProductivity(),
+                survey.getMainScoreValue(),
+                ServerClassification.Companion.get(serverDB.getClassification()));
 
         return nextScheduleDate;
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/planning/SurveyPlanner.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/planning/SurveyPlanner.java
@@ -22,10 +22,12 @@ package org.eyeseetea.malariacare.data.database.utils.planning;
 import org.eyeseetea.malariacare.data.database.model.OrgUnitDB;
 import org.eyeseetea.malariacare.data.database.model.OrgUnitProgramRelationDB;
 import org.eyeseetea.malariacare.data.database.model.ProgramDB;
+import org.eyeseetea.malariacare.data.database.model.ServerDB;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.utils.Session;
 import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 import org.eyeseetea.malariacare.domain.entity.NextScheduleDateConfiguration;
+import org.eyeseetea.malariacare.domain.entity.ServerClassification;
 import org.eyeseetea.malariacare.domain.service.SurveyNextScheduleDomainService;
 import org.eyeseetea.malariacare.utils.Constants;
 
@@ -188,11 +190,15 @@ public class SurveyPlanner {
         SurveyNextScheduleDomainService surveyNextScheduleDomainService = new
                 SurveyNextScheduleDomainService();
 
+        ServerDB serverDB = ServerDB.getConnectedServerFromDB();
+
         Date nextScheduleDate = surveyNextScheduleDomainService.calculate(
                 nextScheduleDateConfiguration,
                 eventDate,
                 competencyScoreClassification,
-                survey.isLowProductivity());
+                survey.isLowProductivity(),
+                survey.getMainScoreValue(),
+                ServerClassification.Companion.get(serverDB.getClassification()));
 
         return nextScheduleDate;
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/NextScheduleDateConfiguration.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/NextScheduleDateConfiguration.java
@@ -4,30 +4,33 @@ import static java.lang.Integer.*;
 
 public class NextScheduleDateConfiguration {
     private final String nextScheduleDeltaMatrix;
-    private int competentHighProductivityMonths;
-    private int competentLowProductivityMonths;
+    private int competentOrAHighProductivityMonths;
+    private int competentOrALowProductivityMonths;
 
-    private int competentNeedsImprovementHighProductivityMonths;
-    private int competentNeedsImprovementLowProductivityMonths;
+    private int competentNeedsImprovementOrBHighProductivityMonths;
+    private int competentNeedsImprovementOrBLowProductivityMonths;
 
-    private int notCompetentHighProductivityMonths;
-    private int notCompetentLowProductivityMonths;
+    private int notCompetentOrCHighProductivityMonths;
+    private int notCompetentOrCLowProductivityMonths;
 
-    /**
-     *
-     * @param nextScheduleDeltaMatrix provide next schedule Date by competency and productivity
-     * Example: 4,4;3,3;3,1
-     *
-     *  |      Program A          | Low Productivity  | High Productivity |
-     *  |-------------------------|-------------------|-------------------|
-     *  |Competency A (Competent) |         4         |        4          |
-     *  |-------------------------|-------------------|-------------------|
-     *  |Competency B (Competent  |                   |                   |
-     *  |needs improvement)       |         3         |        3          |
-     *  |-------------------------|-------------------|-------------------|
-     *  |Competency A (Competent) |         3         |        1          |
-     *  |-------------------------|-------------------|-------------------|
-     */
+        /**
+         *
+         * @param nextScheduleDeltaMatrix provide next schedule Date by competency or score and productivity
+         * Example: 4,4;3,3;3,1
+         *
+         *  |      Program A          | Low Productivity  | High Productivity |
+         *  |-------------------------|-------------------|-------------------|
+         *  |     A (Competent        |                   |                   |
+         *  |    or high score)       |         4         |        4          |
+         *  |-------------------------|-------------------|-------------------|
+         *  |     B (Competent needs  |                   |                   |
+         *  |     improvement or      |         3         |        3          |
+         *  |     medium score)       |                   |                   |
+         *  |-------------------------|-------------------|-------------------|
+         *  |     C (Not Competent    |                   |                   |
+         *  |      or low score)      |         3         |        1          |
+         *  |-------------------------|-------------------|-------------------|
+         */
 
     public NextScheduleDateConfiguration(String nextScheduleDeltaMatrix) {
         if (nextScheduleDeltaMatrix == null){
@@ -52,55 +55,55 @@ public class NextScheduleDateConfiguration {
             }
 
             if (index == 0){
-                extractCompetentNextSchedule(nextSchedulesProductivity);
+                extractCompetentOrANextSchedule(nextSchedulesProductivity);
             } else if(index == 1){
-                extractCompetentNeedsImprovementNextSchedule(nextSchedulesProductivity);
+                extractCompetentNeedsImprovementOrBNextSchedule(nextSchedulesProductivity);
             } else if(index == 2){
-                extractNotCompetentNextSchedule(nextSchedulesProductivity);
+                extractNotCompetentOrCNextSchedule(nextSchedulesProductivity);
             }
         }
     }
 
-    private void extractCompetentNextSchedule(String[] nextSchedulesProductivity) {
-        competentLowProductivityMonths = parseInt(nextSchedulesProductivity[0]);
-        competentHighProductivityMonths = parseInt(nextSchedulesProductivity[1]);
+    private void extractCompetentOrANextSchedule(String[] nextSchedulesProductivity) {
+        competentOrALowProductivityMonths = parseInt(nextSchedulesProductivity[0]);
+        competentOrAHighProductivityMonths = parseInt(nextSchedulesProductivity[1]);
     }
 
-    private void extractCompetentNeedsImprovementNextSchedule(String[] nextSchedulesProductivity) {
-        competentNeedsImprovementLowProductivityMonths = parseInt(nextSchedulesProductivity[0]);
-        competentNeedsImprovementHighProductivityMonths = parseInt(nextSchedulesProductivity[1]);
+    private void extractCompetentNeedsImprovementOrBNextSchedule(String[] nextSchedulesProductivity) {
+        competentNeedsImprovementOrBLowProductivityMonths = parseInt(nextSchedulesProductivity[0]);
+        competentNeedsImprovementOrBHighProductivityMonths = parseInt(nextSchedulesProductivity[1]);
     }
 
-    private void extractNotCompetentNextSchedule(String[] nextSchedulesProductivity) {
-        notCompetentLowProductivityMonths = parseInt(nextSchedulesProductivity[0]);
-        notCompetentHighProductivityMonths = parseInt(nextSchedulesProductivity[1]);
+    private void extractNotCompetentOrCNextSchedule(String[] nextSchedulesProductivity) {
+        notCompetentOrCLowProductivityMonths = parseInt(nextSchedulesProductivity[0]);
+        notCompetentOrCHighProductivityMonths = parseInt(nextSchedulesProductivity[1]);
     }
 
     public String getNextScheduleDeltaMatrix() {
         return nextScheduleDeltaMatrix;
     }
 
-    public int getCompetentHighProductivityMonths() {
-        return competentHighProductivityMonths;
+    public int getCompetentOrAHighProductivityMonths() {
+        return competentOrAHighProductivityMonths;
     }
 
-    public int getCompetentLowProductivityMonths() {
-        return competentLowProductivityMonths;
+    public int getCompetentOrALowProductivityMonths() {
+        return competentOrALowProductivityMonths;
     }
 
-    public int getCompetentNeedsImprovementHighProductivityMonths() {
-        return competentNeedsImprovementHighProductivityMonths;
+    public int getCompetentNeedsImprovementOrBHighProductivityMonths() {
+        return competentNeedsImprovementOrBHighProductivityMonths;
     }
 
-    public int getCompetentNeedsImprovementLowProductivityMonths() {
-        return competentNeedsImprovementLowProductivityMonths;
+    public int getCompetentNeedsImprovementOrBLowProductivityMonths() {
+        return competentNeedsImprovementOrBLowProductivityMonths;
     }
 
-    public int getNotCompetentHighProductivityMonths() {
-        return notCompetentHighProductivityMonths;
+    public int getNotCompetentOrCHighProductivityMonths() {
+        return notCompetentOrCHighProductivityMonths;
     }
 
-    public int getNotCompetentLowProductivityMonths() {
-        return notCompetentLowProductivityMonths;
+    public int getNotCompetentOrCLowProductivityMonths() {
+        return notCompetentOrCLowProductivityMonths;
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoginUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoginUseCase.java
@@ -82,9 +82,9 @@ public class LoginUseCase implements UseCase{
         mUserAccountRepository.login(credentials, new IRepositoryCallback<UserAccount>() {
             @Override
             public void onSuccess(UserAccount userAccount) {
+                updateLoggedServer();
                 getServerVersion();
                 notifyOnLoginSuccess();
-                updateLoggedServer();
             }
 
             @Override
@@ -129,8 +129,7 @@ public class LoginUseCase implements UseCase{
                 }
 
                 if (connectedServer != null){
-                    connectedServer.changeToConnected();
-                    mServerRepository.save(connectedServer);
+                    mServerRepository.save(connectedServer.changeToConnected());
                     mServerRepository.getLoggedServer();
                 }
             } catch (Exception e) {

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
@@ -204,8 +204,8 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
                 new WrapperExecutor(),
                 DataFactory.INSTANCE.provideGetObservationBySurveyUidUseCase(),
                 MetadataFactory.INSTANCE.provideServerMetadataUseCase(getActivity()),
-                DataFactory.INSTANCE.provideSaveObservationUseCase());
-
+                DataFactory.INSTANCE.provideSaveObservationUseCase(),
+                serverClassification);
 
         presenter.attachView(this, surveyUid);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/observations/ObservationsPresenter.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/observations/ObservationsPresenter.kt
@@ -7,6 +7,7 @@ import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification
 import org.eyeseetea.malariacare.domain.entity.NextScheduleDateConfiguration
 import org.eyeseetea.malariacare.domain.entity.Observation
 import org.eyeseetea.malariacare.domain.entity.ObservationStatus
+import org.eyeseetea.malariacare.domain.entity.ServerClassification
 import org.eyeseetea.malariacare.domain.entity.ServerMetadata
 import org.eyeseetea.malariacare.domain.exception.InvalidServerMetadataException
 import org.eyeseetea.malariacare.domain.exception.ObservationNotFoundException
@@ -29,7 +30,8 @@ class ObservationsPresenter(
     private val executor: Executor,
     private val getObservationBySurveyUidUseCase: GetObservationBySurveyUidUseCase,
     private val getServerMetadataUseCase: GetServerMetadataUseCase,
-    private val saveObservationUseCase: SaveObservationUseCase
+    private val saveObservationUseCase: SaveObservationUseCase,
+    private val serverClassification: ServerClassification
 ) {
     private var view: View? = null
 
@@ -130,7 +132,9 @@ class ObservationsPresenter(
                 nextScheduleDateConfiguration,
                 eventDate,
                 competencyScoreClassification,
-                survey.isLowProductivity
+                survey.isLowProductivity,
+                survey.mainScoreValue,
+                serverClassification
             )
 
             formattedNextScheduleDate = dateParser.format(

--- a/app/src/test/java/org/eyeseetea/malariacare/domain/entity/NextScheduleDateConfigurationShould.java
+++ b/app/src/test/java/org/eyeseetea/malariacare/domain/entity/NextScheduleDateConfigurationShould.java
@@ -49,15 +49,15 @@ public class NextScheduleDateConfigurationShould {
         NextScheduleDateConfiguration nextScheduleDateConfiguration =
                 new NextScheduleDateConfiguration("6,5;4,3;2,1");
 
-        assertEquals(6, nextScheduleDateConfiguration.getCompetentLowProductivityMonths());
-        assertEquals(5, nextScheduleDateConfiguration.getCompetentHighProductivityMonths());
+        assertEquals(6, nextScheduleDateConfiguration.getCompetentOrALowProductivityMonths());
+        assertEquals(5, nextScheduleDateConfiguration.getCompetentOrAHighProductivityMonths());
 
         assertEquals(4,
-                nextScheduleDateConfiguration.getCompetentNeedsImprovementLowProductivityMonths());
+                nextScheduleDateConfiguration.getCompetentNeedsImprovementOrBLowProductivityMonths());
         assertEquals(3,
-                nextScheduleDateConfiguration.getCompetentNeedsImprovementHighProductivityMonths());
+                nextScheduleDateConfiguration.getCompetentNeedsImprovementOrBHighProductivityMonths());
 
-        assertEquals(2, nextScheduleDateConfiguration.getNotCompetentLowProductivityMonths());
-        assertEquals(1, nextScheduleDateConfiguration.getNotCompetentHighProductivityMonths());
+        assertEquals(2, nextScheduleDateConfiguration.getNotCompetentOrCLowProductivityMonths());
+        assertEquals(1, nextScheduleDateConfiguration.getNotCompetentOrCHighProductivityMonths());
     }
 }

--- a/app/src/test/java/org/eyeseetea/malariacare/domain/service/SurveyNextScheduleDomainServiceShould.java
+++ b/app/src/test/java/org/eyeseetea/malariacare/domain/service/SurveyNextScheduleDomainServiceShould.java
@@ -1,9 +1,12 @@
 package org.eyeseetea.malariacare.domain.service;
 
+import static org.eyeseetea.malariacare.domain.entity.ScoreType.HIGH_SCORE_HIGHER_THAN;
+import static org.eyeseetea.malariacare.domain.entity.ScoreType.LOW_LOWER_THAN;
 import static org.junit.Assert.assertEquals;
 
 import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 import org.eyeseetea.malariacare.domain.entity.NextScheduleDateConfiguration;
+import org.eyeseetea.malariacare.domain.entity.ServerClassification;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -29,7 +32,9 @@ public class SurveyNextScheduleDomainServiceShould {
                 null,
                 new Date(),
                 CompetencyScoreClassification.COMPETENT,
-                true);
+                true,
+                0,
+                ServerClassification.COMPETENCIES);
     }
 
 
@@ -42,7 +47,9 @@ public class SurveyNextScheduleDomainServiceShould {
                 nextScheduleDateConfiguration,
                 null,
                 CompetencyScoreClassification.COMPETENT,
-                true);
+                true,
+                0,
+                ServerClassification.COMPETENCIES);
     }
 
 
@@ -55,7 +62,23 @@ public class SurveyNextScheduleDomainServiceShould {
                 nextScheduleDateConfiguration,
                 new Date(),
                 null,
-                true);
+                true,
+                0,
+                ServerClassification.COMPETENCIES);
+    }
+
+    @Test
+    public void throw_exception_if_server_classification_is_null() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("serverClassification is required");
+
+        new SurveyNextScheduleDomainService().calculate(
+                nextScheduleDateConfiguration,
+                new Date(),
+                CompetencyScoreClassification.COMPETENT,
+                true,
+                0,
+                null);
     }
 
     @Test
@@ -69,7 +92,9 @@ public class SurveyNextScheduleDomainServiceShould {
                 nextScheduleDateConfiguration,
                 previousSurveyDate,
                 previousSurveyCompetency,
-                true);
+                true,
+                0,
+                ServerClassification.COMPETENCIES);
 
         assertEquals(expectedNextScheduleDate, nextScheduleDate);
     }
@@ -85,9 +110,49 @@ public class SurveyNextScheduleDomainServiceShould {
                 nextScheduleDateConfiguration,
                 previousSurveyDate,
                 previousSurveyCompetency,
-                false);
+                false,
+                0,
+                ServerClassification.COMPETENCIES);
 
         assertEquals(expectedNextScheduleDate, nextScheduleDate);
+    }
+
+    @Test
+    public void should_return_expected_next_schedule_date_by_high_score_low_productivity() {
+        CompetencyScoreClassification previousSurveyCompetency =
+                CompetencyScoreClassification.COMPETENT;
+        Date previousSurveyDate = new Date();
+        Date expectedNextScheduleDate = getInXMonths(previousSurveyDate, 6);
+
+        Date nextScheduleDate = new SurveyNextScheduleDomainService().calculate(
+                nextScheduleDateConfiguration,
+                previousSurveyDate,
+                previousSurveyCompetency,
+                true,
+                HIGH_SCORE_HIGHER_THAN + 5,
+                ServerClassification.SCORING);
+
+        assertEquals(expectedNextScheduleDate, nextScheduleDate);
+
+    }
+
+    @Test
+    public void should_return_expected_next_schedule_date_by_high_score_high_productivity() {
+        CompetencyScoreClassification previousSurveyCompetency =
+                CompetencyScoreClassification.COMPETENT;
+        Date previousSurveyDate = new Date();
+        Date expectedNextScheduleDate = getInXMonths(previousSurveyDate, 5);
+
+        Date nextScheduleDate = new SurveyNextScheduleDomainService().calculate(
+                nextScheduleDateConfiguration,
+                previousSurveyDate,
+                previousSurveyCompetency,
+                false,
+                HIGH_SCORE_HIGHER_THAN + 5,
+                ServerClassification.SCORING);
+
+        assertEquals(expectedNextScheduleDate, nextScheduleDate);
+
     }
 
     @Test
@@ -101,7 +166,9 @@ public class SurveyNextScheduleDomainServiceShould {
                 nextScheduleDateConfiguration,
                 previousSurveyDate,
                 previousSurveyCompetency,
-                true);
+                true,
+                0,
+                ServerClassification.COMPETENCIES);
 
         assertEquals(expectedNextScheduleDate, nextScheduleDate);
     }
@@ -117,7 +184,45 @@ public class SurveyNextScheduleDomainServiceShould {
                 nextScheduleDateConfiguration,
                 previousSurveyDate,
                 previousSurveyCompetency,
-                false);
+                false,
+                0,
+                ServerClassification.COMPETENCIES);
+
+        assertEquals(expectedNextScheduleDate, nextScheduleDate);
+    }
+
+    @Test
+    public void should_return_expected_next_schedule_date_by_medium_score_low_productivity() {
+        CompetencyScoreClassification previousSurveyCompetency =
+                CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT;
+        Date previousSurveyDate = new Date();
+        Date expectedNextScheduleDate = getInXMonths(previousSurveyDate, 4);
+
+        Date nextScheduleDate = new SurveyNextScheduleDomainService().calculate(
+                nextScheduleDateConfiguration,
+                previousSurveyDate,
+                previousSurveyCompetency,
+                true,
+                LOW_LOWER_THAN + 2,
+                ServerClassification.SCORING);
+
+        assertEquals(expectedNextScheduleDate, nextScheduleDate);
+    }
+
+    @Test
+    public void should_return_expected_next_schedule_date_by_medium_score_high_productivity() {
+        CompetencyScoreClassification previousSurveyCompetency =
+                CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT;
+        Date previousSurveyDate = new Date();
+        Date expectedNextScheduleDate = getInXMonths(previousSurveyDate, 3);
+
+        Date nextScheduleDate = new SurveyNextScheduleDomainService().calculate(
+                nextScheduleDateConfiguration,
+                previousSurveyDate,
+                previousSurveyCompetency,
+                false,
+                LOW_LOWER_THAN + 2,
+                ServerClassification.SCORING);
 
         assertEquals(expectedNextScheduleDate, nextScheduleDate);
     }
@@ -133,7 +238,9 @@ public class SurveyNextScheduleDomainServiceShould {
                 nextScheduleDateConfiguration,
                 previousSurveyDate,
                 previousSurveyCompetency,
-                true);
+                true,
+                0,
+                ServerClassification.COMPETENCIES);
 
         assertEquals(expectedNextScheduleDate, nextScheduleDate);
     }
@@ -149,7 +256,45 @@ public class SurveyNextScheduleDomainServiceShould {
                 nextScheduleDateConfiguration,
                 previousSurveyDate,
                 previousSurveyCompetency,
-                false);
+                false,
+                0,
+                ServerClassification.COMPETENCIES);
+
+        assertEquals(expectedNextScheduleDate, nextScheduleDate);
+    }
+
+    @Test
+    public void should_return_expected_next_schedule_date_by_low_score_low_productivity() {
+        CompetencyScoreClassification previousSurveyCompetency =
+                CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT;
+        Date previousSurveyDate = new Date();
+        Date expectedNextScheduleDate = getInXMonths(previousSurveyDate, 2);
+
+        Date nextScheduleDate = new SurveyNextScheduleDomainService().calculate(
+                nextScheduleDateConfiguration,
+                previousSurveyDate,
+                previousSurveyCompetency,
+                true,
+                LOW_LOWER_THAN - 2,
+                ServerClassification.SCORING);
+
+        assertEquals(expectedNextScheduleDate, nextScheduleDate);
+    }
+
+    @Test
+    public void should_return_expected_next_schedule_date_by_low_score_high_productivity() {
+        CompetencyScoreClassification previousSurveyCompetency =
+                CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT;
+        Date previousSurveyDate = new Date();
+        Date expectedNextScheduleDate = getInXMonths(previousSurveyDate, 1);
+
+        Date nextScheduleDate = new SurveyNextScheduleDomainService().calculate(
+                nextScheduleDateConfiguration,
+                previousSurveyDate,
+                previousSurveyCompetency,
+                false,
+                LOW_LOWER_THAN - 2,
+                ServerClassification.SCORING);
 
         assertEquals(expectedNextScheduleDate, nextScheduleDate);
     }
@@ -165,7 +310,9 @@ public class SurveyNextScheduleDomainServiceShould {
                 nextScheduleDateConfiguration,
                 previousSurveyDate,
                 previousSurveyCompetency,
-                true);
+                true,
+                0,
+                ServerClassification.COMPETENCIES);
 
         assertEquals(expectedNextScheduleDate, nextScheduleDate);
     }
@@ -181,10 +328,49 @@ public class SurveyNextScheduleDomainServiceShould {
                 nextScheduleDateConfiguration,
                 previousSurveyDate,
                 previousSurveyCompetency,
-                false);
+                false,
+                0,
+                ServerClassification.COMPETENCIES);
 
         assertEquals(expectedNextScheduleDate, nextScheduleDate);
     }
+
+    @Test
+    public void should_return_expected_next_schedule_date_by_no_score_low_productivity() {
+        CompetencyScoreClassification previousSurveyCompetency =
+                CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT;
+        Date previousSurveyDate = new Date();
+        Date expectedNextScheduleDate = getInXMonths(previousSurveyDate, 2);
+
+        Date nextScheduleDate = new SurveyNextScheduleDomainService().calculate(
+                nextScheduleDateConfiguration,
+                previousSurveyDate,
+                previousSurveyCompetency,
+                true,
+                0,
+                ServerClassification.SCORING);
+
+        assertEquals(expectedNextScheduleDate, nextScheduleDate);
+    }
+
+    @Test
+    public void should_return_expected_next_schedule_date_by_no_score_high_productivity() {
+        CompetencyScoreClassification previousSurveyCompetency =
+                CompetencyScoreClassification.COMPETENT_NEEDS_IMPROVEMENT;
+        Date previousSurveyDate = new Date();
+        Date expectedNextScheduleDate = getInXMonths(previousSurveyDate, 1);
+
+        Date nextScheduleDate = new SurveyNextScheduleDomainService().calculate(
+                nextScheduleDateConfiguration,
+                previousSurveyDate,
+                previousSurveyCompetency,
+                false,
+                0,
+                ServerClassification.SCORING);
+
+        assertEquals(expectedNextScheduleDate, nextScheduleDate);
+    }
+
 
     private Date getInXMonths(Date date, int numMonths) {
         Calendar calendar = Calendar.getInstance();


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2428 
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature/changes_in_next_assessment_logic Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Adjust logic for next assessment based on the following mapping:
C=A
CNI=B
NC=C

### :memo: How is it being implemented?

- I have updated the SurveyNextScheduleDomainService and tests

### :boom: How can it be tested?

Currently in http://data.psi-mis.org/ is not assigned delta matrix to any program then the default delta matrix is asigned.

Program X | Low Productivity | High Productivity
------------ | ------------- | -------------
A (Competent or high score) | 6 | 6
B (Competent needs improvement or medium score) | 4 | 4
C (Not Competent, NA or low score) | 4 | 2

KE HNQIS Family Planning Counseling has a relation with all org units of high productivity
Rest of the programs has a relation with all org units of low productivity

to test different server responses until po editor return classification info by the server, this code help to this goal:

In ServerDB class insert this code replacing the getConnectedServerFromDB:
change serverDB.setClassification for your scenario
```
    public static ServerDB getConnectedServerFromDB() {
        ServerDB serverDB =  new Select().from(ServerDB.class)
                .where(ServerDB_Table.connected.is(true)).querySingle();

        serverDB.setClassification(0); //SCORING
        //serverDB.setClassification(1); //COMPETENCIES
        
        return serverDB;
    }
```

 **Use case 1:** -  Make login and schedule dates in the plan tab should be calculated according to the matrix.

 **Use case 2:** -  create new surveys wait to push, then the next visit CDE should be sent according to the matrix.

 **Use case 3:** -  create new surveys, then for the next planned survey, the date should be calculated according to the matrix.

### :floppy_disk: Requires DB migration?

- [ ] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [x] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

