### PR TITLE
Fix bug when term contains | and empty by server

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/ServerRemoteDataSource.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/ServerRemoteDataSource.kt
@@ -26,12 +26,20 @@ class ServerRemoteDataSource(private val poEditorApiClient: PoEditorApiClient) :
                     if (serverInfoArray.size == 1) {
                         Server(url = serverInfoArray[0])
                     } else {
-                        val classification =
-                            ServerClassification.valueOf(serverInfoArray[1].toUpperCase())
+                        val classification = parseCompetencies(serverInfoArray[1].toUpperCase())
+
                         Server(url = serverInfoArray[0], classification = classification)
                     }
                 }
             }
+        }
+    }
+
+    private fun parseCompetencies(competenciesText: String): ServerClassification {
+        return try {
+            ServerClassification.valueOf(competenciesText)
+        } catch (ex: Exception) {
+            ServerClassification.COMPETENCIES
         }
     }
 

--- a/app/src/test/java/org/eyeseetea/malariacare/data/api/ServerRemoteDataSourceShould.kt
+++ b/app/src/test/java/org/eyeseetea/malariacare/data/api/ServerRemoteDataSourceShould.kt
@@ -20,7 +20,7 @@ class ServerRemoteDataSourceShould {
     var mockWebServerRule = MockWebServerRule(ResourcesFileReader())
 
     @Test
-    fun `return server list with competencies classification by server if classification is empty`() {
+    fun `return server list with competencies classification by server if classification does not exist`() {
         val dataSource = ServerRemoteDataSource(
             PoEditorApiClient(
                 "AnyId",
@@ -82,6 +82,27 @@ class ServerRemoteDataSourceShould {
         }
     }
 
+    @Test
+    fun `return server list with competencies classification by server if classification is empty`() {
+        val dataSource = ServerRemoteDataSource(
+            PoEditorApiClient(
+                "AnyId",
+                "AnyToken",
+                mockWebServerRule.mockServer.baseEndpoint
+            )
+        )
+
+        mockWebServerRule.mockServer.enqueueMockResponse(
+            WITH_EMPTY_CLASSIFICATION_SERVER_LIST_PO_EDITOR_RESPONSE
+        )
+
+        val serversResult = dataSource.getAll()
+
+        serversResult.forEach {
+            Assert.assertEquals(it.classification, ServerClassification.COMPETENCIES)
+        }
+    }
+
     companion object {
         private const val WITHOUT_CLASSIFICATION_SERVER_LIST_PO_EDITOR_RESPONSE =
             "without_classification_server_list_po_editor_response.json"
@@ -89,5 +110,7 @@ class ServerRemoteDataSourceShould {
             "with_competencies_classification_server_list_po_editor_response.json"
         private const val WITH_SCORING_CLASSIFICATION_SERVER_LIST_PO_EDITOR_RESPONSE =
             "with_scoring_classification_server_list_po_editor_response.json"
+        private const val WITH_EMPTY_CLASSIFICATION_SERVER_LIST_PO_EDITOR_RESPONSE =
+            "with_empty_classification_server_list_po_editor_response.json"
     }
 }

--- a/app/src/test/resources/with_empty_classification_server_list_po_editor_response.json
+++ b/app/src/test/resources/with_empty_classification_server_list_po_editor_response.json
@@ -1,0 +1,26 @@
+{
+  "response": {
+    "status": "success",
+    "code": "200",
+    "message": "OK"
+  },
+  "result": {
+    "terms": [
+      {
+        "term": "server_list",
+        "context": "",
+        "plural": "",
+        "created": "2019-12-13T10:40:23+0000",
+        "updated": "",
+        "translation": {
+          "content": "https://data.psi-mis.org/|\nhttps://ao-dev.hnqis.org/|\nhttps://imdatahub.org/|\nhttps://myanmar.psi-mis.org/|\nhttps://sfhza.psi-mis.org/|\nhttps://sm-dev.hnqis.org/|\nhttps://zw.hnqis.org/|",
+          "fuzzy": 0,
+          "updated": "2020-01-15T03:48:32+0000"
+        },
+        "reference": "",
+        "tags": [],
+        "comment": ""
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2420     
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: fix/bug_when_competency_is_empty_after_pipe Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Fix bug when the term contains | and empty by server

### :memo: How is it being implemented?

-  Try parse competencies and if there is an error assign COMPETENCIES.

### :boom: How can it be tested?

to test different server responses until po editor return classification info by server, this code help to this goal:

In PoEditorApiClient class insert this code replacing line 28:
```
val hackedTerm = Term(
    "server_list", Date(), Translation(
        "https://data.psi-mis.org/|\n" +
            "https://ao-dev.hnqis.org/|\n" +
            "https://imdatahub.org/|\n" +
            "https://myanmar.psi-mis.org/|\n" +
            "https://sfhza.psi-mis.org/|\n" +
            "https://sm-dev.hnqis.org/|\n" +
            "https://zw.hnqis.org/|"
    )
)

val mutableTerms = terms.toMutableList()

mutableTerms[247] = hackedTerm
Either.Right(mutableTerms)
```

**use case 1**: start the app with the code with empty classifications by server from new installation and the servers in the database should contain competencies classification

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
