### PR TITLE
Fix/bug qoc with decimals

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/dashboard/AssessmentSentAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/dashboard/AssessmentSentAdapter.java
@@ -131,7 +131,7 @@ public class AssessmentSentAdapter extends RecyclerView.Adapter<RecyclerView.Vie
                     CompetencyUtils.setTextByCompetencyAbbreviation(classificationTextView, classification);
                 } else {
                     if (survey.hasMainScore()){
-                        String value = survey.getMainScore().getScore() + " %";
+                        String value = Math.round(survey.getMainScoreValue()) + " %";
                         classificationTextView.setText(value);
                     } else {
                         classificationTextView.setText("-");


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2428     
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: fix/bug_qoc_with_decimals Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Fix bug with decimals in the improve tab

### :memo: How is it being implemented?

-  Round the decimals and review all screen where the score appears

### :boom: How can it be tested?

to test different server responses until po editor return classification info by server, this code help to this goal:

In PoEditorApiClient class insert this code replacing line 28:
```
val terms = response.body()?.result?.terms ?: listOf()

val hackedTerm = Term(
    "server_list", Date(), Translation(
        "https://data.psi-mis.org/|SCORING\n" +
            "https://ao-dev.hnqis.org/|Scoring\n" +
            "https://imdatahub.org/|scoring\n" +
            "https://myanmar.psi-mis.org/|SCORING\n" +
            "https://sfhza.psi-mis.org/|SCORING\n" +
            "https://sm-dev.hnqis.org/|SCORING\n" +
            "https://zw.hnqis.org/|SCORING"
    )
)

val mutableTerms = terms.toMutableList()

mutableTerms[247] = hackedTerm
Either.Right(mutableTerms)
```

**use case 1**: start the app with the code with SCORING classifications by the server from new installation and the improve tab should show de score without decimals.

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
