### PR TITLE
Fix crash after refresh metadata and fix crash after change language

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/BaseActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/BaseActivity.java
@@ -387,9 +387,8 @@ public abstract class BaseActivity extends AppCompatActivity {
     }
 
     protected void goSettings() {
-        Intent intentSettings = new Intent(this, SettingsActivity.class);
-        intentSettings.putExtra(SETTINGS_CALLER_ACTIVITY, this.getClass());
-        startActivity(new Intent(this, SettingsActivity.class));
+        Intent intent = new Intent(this, SettingsActivity.class);
+        ActivityCompat.startActivity(this, intent, null);
     }
 
     /**

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -19,6 +19,7 @@
 
 package org.eyeseetea.malariacare;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -27,6 +28,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.support.v4.app.ActivityCompat;
 import android.telephony.TelephonyManager;
 import android.text.SpannableString;
 import android.text.method.LinkMovementMethod;
@@ -192,7 +194,9 @@ public class DashboardActivity extends BaseActivity {
             return;
         }
         PreferencesState.getInstance().clearOrgUnitPreference();
-        finishAndGo(ProgressActivity.class);
+
+        Intent intent = new Intent(this, ProgressActivity.class);
+        ActivityCompat.startActivity(this, intent, null);
     }
 
     @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/ModuleController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/ModuleController.java
@@ -223,7 +223,7 @@ public abstract class ModuleController {
 
         FragmentTransaction ft = getFragmentTransaction();
         ft.replace(layout, fragment);
-        ft.commit();
+        ft.commitAllowingStateLoss();
     }
 
     public FragmentTransaction getFragmentTransaction() {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2438 and #2440 
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: fix/crash_after_refresh_metadata Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Fix crash after refresh metadata and fix crash after change language

### :memo: How is it being implemented?

After many tests, I have found the problem. This bug seems related to commit fragments from the OnResume method in the activity.

I have followed the advice in https://www.androiddesignpatterns.com/2013/08/fragment-transaction-commit-state-loss.html

First I have removed the reloadActiveTab invocation from onResume in the DashboardActivity that replaces the current fragment using commit. 

I think this is not a problem because after back from inProgress o settings activity to DashboardActivity the current tab has been created in the onCreate method from the activity and when the current tab change we reload the tab.

However, this provokes other errors in or app with our special approach to manage fragments and tabs.

So I have used the commitAllowingStateLoss() only as a last resort as recommended the article

### :boom: How can it be tested?

**use case 1**: Log in and pull should work and navigate to the dashboard without crash
**use case 2**: Refresh metadata should work and navigate to the dashboard without crash
**use case 3**: Navigate to settings to change language and back to the Dashboard Activity should work without any crash.

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
