### PR TITLE
Feature/upgrade to api 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ android:
   - tools
   - platform-tools
   - build-tools-29.0.3
+  - build-tools-28.0.3
   - android-29
   - android-28
   - android-27

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-28.0.3
+  - build-tools-29.0.3
+  - android-29
   - android-28
   - android-27
   - android-26

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -24,6 +24,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -122,10 +123,13 @@ public class DashboardActivity extends BaseActivity {
         return phoneMetaData;
     }
 
-
     public void loadPhoneMetadata() {
-        PhoneMetaData phoneMetaData = getPhoneMetadata();
-        Session.setPhoneMetaData(phoneMetaData);
+        //Only It's possible until API 28
+        //https://source.android.com/devices/tech/config/device-identifiers
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            PhoneMetaData phoneMetaData = getPhoneMetadata();
+            Session.setPhoneMetaData(phoneMetaData);
+        }
     }
 
     /**

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -22,6 +22,7 @@ package org.eyeseetea.malariacare.data.database.iomodules.dhis.exporter;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.location.Location;
+import android.os.Build;
 import android.util.Log;
 
 import org.eyeseetea.malariacare.R;
@@ -39,6 +40,7 @@ import org.eyeseetea.malariacare.data.database.model.ValueDB;
 import org.eyeseetea.malariacare.data.database.utils.LocationMemory;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.Session;
+import org.eyeseetea.malariacare.data.database.utils.metadata.PhoneMetaData;
 import org.eyeseetea.malariacare.data.sync.IData;
 import org.eyeseetea.malariacare.domain.boundary.IPushController;
 import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
@@ -463,7 +465,10 @@ public class ConvertToSDKVisitor implements
         }
 
         //Push Device
-        if (controlDataElementExistsInServer(pushDeviceCode)) {
+        //Only It's possible until API 28
+        //https://source.android.com/devices/tech/config/device-identifiers
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q &&
+                controlDataElementExistsInServer(pushDeviceCode)) {
             addOrUpdateDataValue(pushDeviceCode,
                     Session.getPhoneMetaData().getPhone_metaData() + "###" + AUtils.getCommitHash(
                             context));

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/FiltersFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/FiltersFragment.java
@@ -60,7 +60,7 @@ public abstract class FiltersFragment extends Fragment implements IModuleFragmen
     }
 
     private void initializeFilters() {
-        if (orgUnitProgramFilterView == null) {
+        if (orgUnitProgramFilterView == null && DashboardActivity.dashboardActivity != null) {
             orgUnitProgramFilterView = DashboardActivity.dashboardActivity
                     .findViewById(getOrgUnitProgramFilterViewId());
 

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/Permissions.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/Permissions.java
@@ -74,8 +74,11 @@ public class Permissions {
                 android.Manifest.permission.ACCESS_FINE_LOCATION));
         addPermission(new Permission(READ_ACCOUNTS_STATE_REQUEST_CODE,
                 Manifest.permission.GET_ACCOUNTS));
-        addPermission(new Permission(PHONE_STATE_REQUEST_CODE,
-                android.Manifest.permission.READ_PHONE_STATE));
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q){
+            addPermission(new Permission(PHONE_STATE_REQUEST_CODE,
+                    android.Manifest.permission.READ_PHONE_STATE));
+        }
     }
 
     public void addPermission(Permission permission) {

--- a/app/src/test/java/org/eyeseetea/malariacare/common/ResourcesFileReader.kt
+++ b/app/src/test/java/org/eyeseetea/malariacare/common/ResourcesFileReader.kt
@@ -25,7 +25,7 @@ class ResourcesFileReader : IFileReader {
     companion object {
         private fun getFile(clazz: Class<*>, filename: String): File {
             val classLoader = clazz.classLoader
-            val resource = classLoader.getResource(filename)
+            val resource = classLoader!!.getResource(filename)
             return File(resource.path)
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -41,10 +41,10 @@ allprojects {
 ext {
     configuration = [
             package          : "org.hisp.dhis.android.skeleton",
-            buildToolsVersion: "28.0.3",
+            buildToolsVersion: "29.0.3",
             minSdkVersion    : 16,
-            compileSdkVersion: 28,
-            targetSdkVersion : 28,
+            compileSdkVersion: 29,
+            targetSdkVersion : 29,
             versionCode      : 63,
             versionName      : "QAApp"
     ]


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2442 
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: eature/upgrade_to_api_29 Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Try upgrade to API 29

### :memo: How is it being implemented?

My first intention was to upgrade to API 30 but I have not found guidelines to upgrade to API 30 in the documentation. The last guideline is to upgrade to API 29.

https://developer.android.com/distribute/best-practices/develop/target-sdk?hl=es

I have updated BuidTools, compileSdkVersion y targetSdkVersion to API 29 and when I have started to test, after pull the app crash because from API 29 there are privileged permissions as `read phone state`.

https://developer.android.com/about/versions/10/privacy/changes#data-ids
https://source.android.com/devices/tech/config/device-identifiers

We are using the metadata phone and to send it as a CDE (push device), in the push process.

I have modified the code to don't request READ_PHONE_STATE permission if the device has Android API 29 or bigger and then we don’t send CDE push device in the push process. For API 28 and lower works as up to now.

I have modified Travis to include build tools 29 and SDK 29.

I have tested the app and it works for 28 with READ_PHONE_STATE permission and sending  CDE push device in the push process.
I have tested the app and it works for 29 without READ_PHONE_STATE permission and does not send CDE push device in the push process.

There are some things to review in the future because this app is old and now we have not time.

- The support library is version 28, I can't upgrade to 29 because it does not exist. We should migrate to Android X, but this supposes migrate to Android X all submodules including the UI part of the SDK.
- I have had problems with Travis because the submodules has API 25 as target SDK and this is a problem in Travis if you don’t include build tools 28 and 29 (for the app) because by default assign 28 if it’s lower. We should review submodules (SDK, bugshaker and eyesetea-sdk) to modify it from API 25 to API 29 and remove build tools 28 from the Travis config file.
- We should review bugshaker submodule to try to use the development branch instead of the downgrade_gradle_version branch
- There are a lot of related to deprecate warnings to build the app

```/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/fragments/CreateSurveyFragment.java:29: warning: [deprecation] PreferenceManager in android.preference has been deprecated
import android.preference.PreferenceManager;
                         ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/FeedbackAdapter.java:41: warning: [deprecation] StringEscapeUtils in org.apache.commons.lang3 has been deprecated
import org.apache.commons.lang3.StringEscapeUtils;
                               ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java:32: warning: [deprecation] PreferenceManager in android.preference has been deprecated
import android.preference.PreferenceManager;
                         ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/utils/AUtils.java:27: warning: [deprecation] NetworkInfo in android.net has been deprecated
import android.net.NetworkInfo;
                  ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/ProgressActivity.java:29: warning: [deprecation] PreferenceManager in android.preference has been deprecated
import android.preference.PreferenceManager;
                         ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/drive/DriveRestController.java:9: warning: [deprecation] NetworkInfo in android.net has been deprecated
import android.net.NetworkInfo;
                  ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/PullDhisSDKDataSource.java:24: warning: [deprecation] NetworkInfo in android.net has been deprecated
import android.net.NetworkInfo;
                  ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/ServerInfoLocalDataSource.java:5: warning: [deprecation] PreferenceManager in android.preference has been deprecated
import android.preference.PreferenceManager;
                         ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/UserAccountLocalDataSource.java:24: warning: [deprecation] PreferenceManager in android.preference has been deprecated
import android.preference.PreferenceManager;
                         ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/LocationMemory.java:26: warning: [deprecation] PreferenceManager in android.preference has been deprecated
import android.preference.PreferenceManager;
                         ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java:28: warning: [deprecation] PreferenceManager in android.preference has been deprecated
import android.preference.PreferenceManager;
                         ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/ServerInfoRemoteDataSource.java:5: warning: [deprecation] PreferenceManager in android.preference has been deprecated
import android.preference.PreferenceManager;
                         ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/data/remote/sdk/UserAccountDhisSDKDataSource.java:24: warning: [deprecation] NetworkInfo in android.net has been deprecated
import android.net.NetworkInfo;
                  ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoadUserAndCredentialsUseCase.java:24: warning: [deprecation] PreferenceManager in android.preference has been deprecated
import android.preference.PreferenceManager;
                         ^
/Users/xurxodev/Workspace/EyeSeeTea/android/malariapp/app/src/main/java/org/eyeseetea/malariacare/EyeSeeTeaApplication.java:27: warning: [deprecation] PreferenceManager in android.preference has been deprecated
import android.preference.PreferenceManager;
```

### :boom: How can it be tested?

**use case 1**: App should work in API 28 and the app should request the READ_PHONE_STATE and send this info in the push process
**use case 2**: App should work in API 29 and the app should don't request the READ_PHONE_STATE and don't send this info in the push process

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
