### PR TITLE
Get only relevant non critical questions to calculate competency :

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/QuestionDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/QuestionDB.java
@@ -931,7 +931,8 @@ public class QuestionDB extends BaseModel {
                 .queryList();
     }
 
-    public static List<QuestionDB> getAnsweredQuestions(long idSurvey, boolean critical) {
+    public static List<QuestionDB> getNonCriticalAnsweredQuestions(long idSurvey) {
+        // returns non critical answered with numerator and denominator
         return SQLite.select()
                 .from(QuestionDB.class).as(questionName)
                 .join(ValueDB.class, Join.JoinType.LEFT_OUTER).as(valueName)
@@ -941,7 +942,9 @@ public class QuestionDB extends BaseModel {
                 .on(OptionDB_Table.id_answer_fk.withTable(optionFlowAlias)
                         .eq(QuestionDB_Table.id_answer_fk.withTable(questionAlias)))
                 .where(ValueDB_Table.id_survey_fk.eq(idSurvey))
-                .and(QuestionDB_Table.compulsory.is(critical))
+                .and(QuestionDB_Table.compulsory.is(false))
+                .and(QuestionDB_Table.numerator_w.isNot(0.0f))
+                .and(QuestionDB_Table.denominator_w.isNot(0.0f))
                 .and(ValueDB_Table.value.withTable(valueAlias).is(OptionDB_Table.name.withTable(optionFlowAlias)))
                 .queryList();
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/CompleteSurveyUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/CompleteSurveyUseCase.java
@@ -60,7 +60,7 @@ public class CompleteSurveyUseCase implements UseCase {
                             "nonCriticalStepsScore");
 
             List<QuestionDB> nonCriticalAnsweredQuestions =
-                    QuestionDB.getAnsweredQuestions(surveyDB.getId_survey(), false);
+                    QuestionDB.getNonCriticalAnsweredQuestions(surveyDB.getId_survey());
 
             CompetencyScoreClassification competencyScoreClassification =
                     competencyScoreCalculationDomainService.calculateClassification(


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2448 
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance/avoid_count_questions_without_numerator_denominator Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Expected behavior:
'Competent' classification is given when All critical questions correct AND 
(≥ 89.9% non critical questions correct OR
none of the non-critical steps were answered)

It is also expected that if a question does not have a numerator and denominator will NOT be taken into consideration in the overall score neither in the competency classification.



### :memo: How is it being implemented?

-I have modified the query to get answered non-critical questions.

### :boom: How can it be tested?

**use case 1**: create a survey KE HNQIS Hypertension program, answer with yes all the critical questions and respond only to the "Is this real or simulated observation?" question. The competency result should be competent.

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

