### PR TITLE
Create new server in db if logged server does not exist

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoginUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoginUseCase.java
@@ -37,7 +37,7 @@ import java.net.MalformedURLException;
 import java.net.UnknownHostException;
 import java.util.List;
 
-public class LoginUseCase implements UseCase{
+public class LoginUseCase implements UseCase {
 
     public interface Callback {
         void onLoginSuccess();
@@ -96,7 +96,7 @@ public class LoginUseCase implements UseCase{
                     notifyOnInvalidCredentials();
                 } else if (throwable instanceof NetworkException) {
                     notifyOnNetworkError();
-                } else if (throwable instanceof UnsupportedServerVersionException){
+                } else if (throwable instanceof UnsupportedServerVersionException) {
                     notifyOnServerVersionError();
                 }
             }
@@ -104,7 +104,7 @@ public class LoginUseCase implements UseCase{
     }
 
     private void getServerVersion() {
-        if(!credentials.isDemoCredentials()) {
+        if (!credentials.isDemoCredentials()) {
             try {
                 mServerInfoRepository.getServerInfo(ReadPolicy.NETWORK_FIRST);
             } catch (Exception e) {
@@ -116,22 +116,24 @@ public class LoginUseCase implements UseCase{
     }
 
     private void updateLoggedServer() {
-        if(!credentials.isDemoCredentials()) {
+        if (!credentials.isDemoCredentials()) {
             try {
                 List<Server> servers = mServerRepository.getAll(ReadPolicy.CACHE);
 
                 Server connectedServer = null;
 
-                for (Server server:servers) {
-                    if (server.getUrl().equals(this.credentials.getServerURL())){
+                for (Server server : servers) {
+                    if (server.getUrl().equals(this.credentials.getServerURL())) {
                         connectedServer = server;
                     }
                 }
 
-                if (connectedServer != null){
-                    mServerRepository.save(connectedServer.changeToConnected());
-                    mServerRepository.getLoggedServer();
+                if (connectedServer == null) {
+                    connectedServer = new Server(this.credentials.getServerURL());
                 }
+
+                mServerRepository.save(connectedServer.changeToConnected());
+                mServerRepository.getLoggedServer();
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -155,6 +157,7 @@ public class LoginUseCase implements UseCase{
             }
         });
     }
+
     private void notifyOnInvalidCredentials() {
         mMainExecutor.run(new Runnable() {
             @Override
@@ -163,6 +166,7 @@ public class LoginUseCase implements UseCase{
             }
         });
     }
+
     private void notifyOnNetworkError() {
         mMainExecutor.run(new Runnable() {
             @Override
@@ -171,6 +175,7 @@ public class LoginUseCase implements UseCase{
             }
         });
     }
+
     private void notifyOnServerVersionError() {
         mMainExecutor.run(new Runnable() {
             @Override


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2451  
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: maintenance/fix_bug_in_pull_if_insert_server_manually Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

When the user inserts the server manually, this server is not created in the server table. This provokes an error during the login/pull .

### :memo: How is it being implemented?

- When in the LoginUseCase after login, we are going to update the server in the database as conected, if the server does not exist then we create it previously.

### :boom: How can it be tested?

**use case 1**: Realize login against a server that it's not in the list, after login the server should be created in the database and mark as connected.

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

