### PR TITLE
Feature/verify user authority

### DIFF
--- a/app/src/androidTest/java/org/eyeseetea/malariacare/domain/usecase/LoginUseCaseShould.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/domain/usecase/LoginUseCaseShould.java
@@ -21,7 +21,9 @@ package org.eyeseetea.malariacare.domain.usecase;
 
 import android.support.test.InstrumentationRegistry;
 
+import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.database.datasources.ServerInfoLocalDataSource;
+import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.file.AssetsFileReader;
 import org.eyeseetea.malariacare.data.remote.api.ServerInfoRemoteDataSource;
 import org.eyeseetea.malariacare.data.repositories.ServerInfoRepository;
@@ -29,8 +31,12 @@ import org.eyeseetea.malariacare.data.repositories.ServerRepository;
 import org.eyeseetea.malariacare.data.repositories.UserAccountRepository;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserFailure;
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserRepository;
+import org.eyeseetea.malariacare.domain.common.Either;
 import org.eyeseetea.malariacare.domain.entity.Credentials;
 import org.eyeseetea.malariacare.domain.entity.ServerInfo;
+import org.eyeseetea.malariacare.domain.entity.User;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.rules.MockWebServerRule;
 import org.junit.Assert;
@@ -43,6 +49,8 @@ import org.mockito.junit.MockitoRule;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+
 public class LoginUseCaseShould {
 
     private static final String SYSTEM_INFO_VERSION_30 = "system_info_30.json";
@@ -54,6 +62,8 @@ public class LoginUseCaseShould {
     public MockWebServerRule mockWebServerRule = new MockWebServerRule(new AssetsFileReader());
     @Mock
     ServerRepository serverRepository;
+    @Mock
+    UserRepository mUserRepository;
     @Mock
     ServerInfoLocalDataSource mServerLocalDataSource;
     @Test
@@ -82,6 +92,11 @@ public class LoginUseCaseShould {
             @Override
             public void onNetworkError() {
                 fail("onNetworkError");
+            }
+
+            @Override
+            public void onRequiredAuthorityError(String authority) {
+                fail("onRequiredAuthorityError");
             }
 
             @Override
@@ -117,6 +132,10 @@ public class LoginUseCaseShould {
             }
 
             @Override
+            public void onRequiredAuthorityError(String authority) {
+                fail("onRequiredAuthorityError");
+            }
+            @Override
             public void onNetworkError() {
                 fail("onNetworkError");
             }
@@ -137,6 +156,8 @@ public class LoginUseCaseShould {
             }
         };
         when(mServerLocalDataSource.get()).thenReturn(new ServerInfo(serverVersion));
+
+        when(mUserRepository.getCurrent()).thenReturn(new Either.Right(new User("id","name",new ArrayList<>())));
         ServerInfoRemoteDataSource mServerRemoteDataSource = new ServerInfoRemoteDataSource(InstrumentationRegistry.getTargetContext());
         ServerInfoRepository serverInfoRepository = new ServerInfoRepository(mServerLocalDataSource, mServerRemoteDataSource);
         return new LoginUseCase(

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/domain/usecase/PushUseCaseShould.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/domain/usecase/PushUseCaseShould.java
@@ -24,6 +24,7 @@ import org.eyeseetea.malariacare.data.database.iomodules.dhis.exporter.PushDataC
 import org.eyeseetea.malariacare.data.file.AssetsFileReader;
 import org.eyeseetea.malariacare.data.remote.api.ServerInfoRemoteDataSource;
 import org.eyeseetea.malariacare.data.repositories.ServerInfoRepository;
+import org.eyeseetea.malariacare.data.repositories.UserD2ApiRepository;
 import org.eyeseetea.malariacare.domain.boundary.IPushController;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
@@ -65,53 +66,9 @@ public class PushUseCaseShould {
         loginUseCase.execute(credentials, new PushUseCase.Callback() {
 
             @Override
-            public void onComplete(PushDataController.Kind kind) { Assert.assertTrue(true); }
-
-            @Override
-            public void onPushError() {
-                fail("onLoginSuccess");
-            }
-
-            @Override
-            public void onPushInProgressError() { fail("onLoginSuccess"); }
-
-            @Override
-            public void onSurveysNotFoundError() { fail("onSurveysNotFoundError"); }
-
-            @Override
-            public void onInformativeError(String message) {
-                fail("onLoginSuccess");
-            }
-
-            @Override
-            public void onConversionError() {
-                fail("onLoginSuccess");
-            }
-
-            @Override
-            public void onNetworkError() {
-                fail("onNetworkError");
-            }
-
-            @Override
-            public void onServerVersionError() {
-                fail("onLoginSuccess");
-            }
-        });
-    }
-
-    @Test
-    public void return_on_complete_when_server_version_is_equals_to_persisted_version() throws Exception {
-        Credentials credentials = new Credentials(mockWebServerRule.getMockServer().getBaseEndpoint(), "user", "password");
-        int actualVersion = 30;
-        PushUseCase loginUseCase = givenPushUseCase(credentials, actualVersion);
-
-        mockWebServerRule.getMockServer().enqueueMockResponseFileName(200, SYSTEM_INFO_VERSION_30);
-        loginUseCase.execute(credentials, new PushUseCase.Callback() {
-
-            @Override
             public void onComplete(PushDataController.Kind kind) {
-                Assert.assertTrue(true); }
+                Assert.assertTrue(true);
+            }
 
             @Override
             public void onPushError() {
@@ -124,7 +81,9 @@ public class PushUseCaseShould {
             }
 
             @Override
-            public void onSurveysNotFoundError() { fail("onSurveysNotFoundError"); }
+            public void onSurveysNotFoundError() {
+                fail("onSurveysNotFoundError");
+            }
 
             @Override
             public void onInformativeError(String message) {
@@ -145,12 +104,76 @@ public class PushUseCaseShould {
             public void onServerVersionError() {
                 fail("onLoginSuccess");
             }
+            @Override
+            public void onRequiredAuthorityError(String authority) {
+                fail("onRequiredAuthorityError");
+            }
         });
     }
 
     @Test
-    public void return_on_server_version_error_when_server_version_is_greater_than_saved_version() throws Exception {
-        Credentials credentials = new Credentials(mockWebServerRule.getMockServer().getBaseEndpoint(), "user", "password");
+    public void return_on_complete_when_server_version_is_equals_to_persisted_version()
+            throws Exception {
+        Credentials credentials = new Credentials(
+                mockWebServerRule.getMockServer().getBaseEndpoint(), "user", "password");
+        int actualVersion = 30;
+        PushUseCase loginUseCase = givenPushUseCase(credentials, actualVersion);
+
+        mockWebServerRule.getMockServer().enqueueMockResponseFileName(200, SYSTEM_INFO_VERSION_30);
+        loginUseCase.execute(credentials, new PushUseCase.Callback() {
+
+            @Override
+            public void onComplete(PushDataController.Kind kind) {
+                Assert.assertTrue(true);
+            }
+
+            @Override
+            public void onPushError() {
+                fail("onLoginSuccess");
+            }
+
+            @Override
+            public void onPushInProgressError() {
+                fail("onLoginSuccess");
+            }
+
+            @Override
+            public void onSurveysNotFoundError() {
+                fail("onSurveysNotFoundError");
+            }
+
+            @Override
+            public void onInformativeError(String message) {
+                fail("onLoginSuccess");
+            }
+
+            @Override
+            public void onConversionError() {
+                fail("onLoginSuccess");
+            }
+
+            @Override
+            public void onNetworkError() {
+                fail("onNetworkError");
+            }
+
+            @Override
+            public void onServerVersionError() {
+                fail("onLoginSuccess");
+            }
+
+            @Override
+            public void onRequiredAuthorityError(String authority) {
+                fail("onRequiredAuthorityError");
+            }
+        });
+    }
+
+    @Test
+    public void return_on_server_version_error_when_server_version_is_greater_than_saved_version()
+            throws Exception {
+        Credentials credentials = new Credentials(
+                mockWebServerRule.getMockServer().getBaseEndpoint(), "user", "password");
         int actualVersion = 30;
         PushUseCase loginUseCase = givenPushUseCase(credentials, actualVersion);
 
@@ -196,12 +219,19 @@ public class PushUseCaseShould {
             public void onServerVersionError() {
                 Assert.assertTrue(true);
             }
+
+            @Override
+            public void onRequiredAuthorityError(String authority) {
+                fail("onRequiredAuthorityError");
+            }
         });
     }
 
     @Test
-    public void return_on_server_version_error_when_server_version_is_lower_than_saved_version() throws Exception {
-        Credentials credentials = new Credentials(mockWebServerRule.getMockServer().getBaseEndpoint(), "user", "password");
+    public void return_on_server_version_error_when_server_version_is_lower_than_saved_version()
+            throws Exception {
+        Credentials credentials = new Credentials(
+                mockWebServerRule.getMockServer().getBaseEndpoint(), "user", "password");
         int actualVersion = 31;
         PushUseCase loginUseCase = givenPushUseCase(credentials, actualVersion);
 
@@ -247,12 +277,18 @@ public class PushUseCaseShould {
             public void onServerVersionError() {
                 Assert.assertTrue(true);
             }
+
+            @Override
+            public void onRequiredAuthorityError(String authority) {
+                fail("onRequiredAuthorityError");
+            }
         });
     }
 
     @Test
     public void return_on_complete_when_server_version_is_not_persisted_on_push() throws Exception {
-        Credentials credentials = new Credentials(mockWebServerRule.getMockServer().getBaseEndpoint(), "user", "password");
+        Credentials credentials = new Credentials(
+                mockWebServerRule.getMockServer().getBaseEndpoint(), "user", "password");
         int actualVersion = -1;
         PushUseCase loginUseCase = givenPushUseCase(credentials, actualVersion);
 
@@ -299,8 +335,14 @@ public class PushUseCaseShould {
             public void onServerVersionError() {
                 fail("onServerVersionError");
             }
+
+            @Override
+            public void onRequiredAuthorityError(String authority) {
+                fail("onRequiredAuthorityError");
+            }
         });
     }
+
     private PushUseCase givenPushUseCase(Credentials credentials, int serverVersion) {
         IMainExecutor mainExecutor = new UIThreadExecutor();
         IAsyncExecutor asyncExecutor = new IAsyncExecutor() {
@@ -328,6 +370,8 @@ public class PushUseCaseShould {
         when(mServerLocalDataSource.get()).thenReturn(new ServerInfo(serverVersion));
         ServerInfoRemoteDataSource serverInfoRemoteDataSource = new ServerInfoRemoteDataSource(
                 InstrumentationRegistry.getTargetContext());
-        return new PushUseCase(pushController, mainExecutor, asyncExecutor, new ServerInfoRepository(mServerLocalDataSource, serverInfoRemoteDataSource));
+        return new PushUseCase(pushController, mainExecutor, asyncExecutor,
+                new ServerInfoRepository(mServerLocalDataSource, serverInfoRemoteDataSource),
+                new UserD2ApiRepository());
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
@@ -367,6 +367,12 @@ public class LoginActivity extends Activity implements LoginPresenter.View {
                     }
 
                     @Override
+                    public void onRequiredAuthorityError(String authority) {
+                        showError(PreferencesState.getInstance().getContext().getString(
+                                R.string.required_authority_error));
+                    }
+
+                    @Override
                     public void onUnsupportedServerVersion() {
                         showError(PreferencesState.getInstance().getContext().getString(
                                 R.string.login_error_unsupported_server_version));

--- a/app/src/main/java/org/eyeseetea/malariacare/data/d2api/BasicAuthInterceptor.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/d2api/BasicAuthInterceptor.kt
@@ -1,0 +1,20 @@
+package org.eyeseetea.malariacare.data.d2api
+
+import okhttp3.Credentials
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+
+class BasicAuthInterceptor(user: String, password: String) :
+    Interceptor {
+    private val credentials: String = Credentials.basic(user, password)
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request: Request = chain.request()
+        val authenticatedRequest: Request = request.newBuilder()
+            .header("Authorization", credentials).build()
+        return chain.proceed(authenticatedRequest)
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/data/d2api/UserD2Api.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/d2api/UserD2Api.kt
@@ -1,0 +1,10 @@
+package org.eyeseetea.malariacare.data.d2api
+
+import org.eyeseetea.malariacare.domain.entity.User
+import retrofit2.Call
+import retrofit2.http.GET
+
+interface UserD2Api {
+    @GET("api/me?fields=id,name,authorities")
+    fun getMe(): Call<User>
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/data/repositories/UserD2ApiRepository.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/repositories/UserD2ApiRepository.kt
@@ -13,7 +13,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 class UserD2ApiRepository() : UserRepository {
 
-    private val userD2Api: UserD2Api;
+    private val userD2Api: UserD2Api
 
     init {
         val credentials = PreferencesState.getInstance().creedentials

--- a/app/src/main/java/org/eyeseetea/malariacare/data/repositories/UserD2Repository.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/repositories/UserD2Repository.kt
@@ -1,0 +1,51 @@
+package org.eyeseetea.malariacare.data.repositories
+
+import okhttp3.OkHttpClient
+import org.eyeseetea.malariacare.data.d2api.BasicAuthInterceptor
+import org.eyeseetea.malariacare.data.d2api.UserD2Api
+import org.eyeseetea.malariacare.data.database.utils.PreferencesState
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserFailure
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserRepository
+import org.eyeseetea.malariacare.domain.common.Either
+import org.eyeseetea.malariacare.domain.entity.User
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class UserD2ApiRepository() : UserRepository {
+
+    private val userD2Api: UserD2Api;
+
+    init {
+        val credentials = PreferencesState.getInstance().creedentials
+
+        val authInterceptor = BasicAuthInterceptor(credentials.username, credentials.password)
+
+        val retrofit: Retrofit = Retrofit.Builder()
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(
+                OkHttpClient.Builder()
+                    .addInterceptor(authInterceptor).build()
+            )
+            .baseUrl(credentials.serverURL)
+            .build()
+
+        userD2Api = retrofit.create(UserD2Api::class.java)
+    }
+
+    override fun getCurrent(): Either<UserFailure, User> {
+        return try {
+            val userResponse = userD2Api.getMe().execute()
+
+            if (userResponse!!.isSuccessful && userResponse.body() != null) {
+                val user = userResponse.body()
+
+                Either.Right(user!!)
+            } else {
+                val error = userResponse.errorBody()!!.string()
+                Either.Left(UserFailure.UnexpectedError)
+            }
+        } catch (e: Exception) {
+            Either.Left(UserFailure.NetworkFailure)
+        }
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/UserRepository.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/UserRepository.kt
@@ -11,4 +11,3 @@ sealed class UserFailure {
 interface UserRepository {
     fun getCurrent(): Either<UserFailure, User>
 }
-

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/UserRepository.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/UserRepository.kt
@@ -1,0 +1,14 @@
+package org.eyeseetea.malariacare.domain.boundary.repositories
+
+import org.eyeseetea.malariacare.domain.common.Either
+import org.eyeseetea.malariacare.domain.entity.User
+
+sealed class UserFailure {
+    object UnexpectedError : UserFailure()
+    object NetworkFailure : UserFailure()
+}
+
+interface UserRepository {
+    fun getCurrent(): Either<UserFailure, User>
+}
+

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/User.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/User.kt
@@ -1,0 +1,3 @@
+package org.eyeseetea.malariacare.domain.entity
+
+data class User(val uid: String, val name: String, val authorities: List<String>)

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/User.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/User.kt
@@ -1,3 +1,5 @@
 package org.eyeseetea.malariacare.domain.entity
 
+const val REQUIRED_AUTHORITY = "F_IGNORE_TRACKER_REQUIRED_VALUE_VALIDATION"
+
 data class User(val uid: String, val name: String, val authorities: List<String>)

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoginUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoginUseCase.java
@@ -25,12 +25,17 @@ import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IServerInfoRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IServerRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IUserAccountRepository;
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserFailure;
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserRepository;
+import org.eyeseetea.malariacare.domain.common.Either;
 import org.eyeseetea.malariacare.domain.entity.Credentials;
 import org.eyeseetea.malariacare.domain.entity.Server;
+import org.eyeseetea.malariacare.domain.entity.User;
 import org.eyeseetea.malariacare.domain.entity.UserAccount;
 import org.eyeseetea.malariacare.domain.common.ReadPolicy;
 import org.eyeseetea.malariacare.domain.exception.InvalidCredentialsException;
 import org.eyeseetea.malariacare.domain.exception.NetworkException;
+import org.eyeseetea.malariacare.layout.utils.LayoutUtils;
 import org.hisp.dhis.client.sdk.models.common.UnsupportedServerVersionException;
 
 import java.net.MalformedURLException;
@@ -48,6 +53,8 @@ public class LoginUseCase implements UseCase {
 
         void onNetworkError();
 
+        void onRequiredAuthorityError(String authority);
+
         void onUnsupportedServerVersion();
     }
 
@@ -56,12 +63,16 @@ public class LoginUseCase implements UseCase {
     private IUserAccountRepository mUserAccountRepository;
     private IServerRepository mServerRepository;
     private IServerInfoRepository mServerInfoRepository;
+    private UserRepository userRepository;
     private Credentials credentials;
     private Callback callback;
+
+    private String REQUIRED_AUTHORITY = "F_IGNORE_TRACKER_REQUIRED_VALUE_VALIDATION";
 
     public LoginUseCase(IUserAccountRepository userAccountRepository,
             IServerRepository serverRepository,
             IServerInfoRepository serverInfoRepository,
+            UserRepository userRepository,
             IMainExecutor mainExecutor,
             IAsyncExecutor asyncExecutor) {
         mMainExecutor = mainExecutor;
@@ -69,6 +80,7 @@ public class LoginUseCase implements UseCase {
         mServerRepository = serverRepository;
         mUserAccountRepository = userAccountRepository;
         mServerInfoRepository = serverInfoRepository;
+        this.userRepository = userRepository;
     }
 
     public void execute(Credentials credentials, final Callback callback) {
@@ -82,9 +94,13 @@ public class LoginUseCase implements UseCase {
         mUserAccountRepository.login(credentials, new IRepositoryCallback<UserAccount>() {
             @Override
             public void onSuccess(UserAccount userAccount) {
-                updateLoggedServer();
-                getServerVersion();
-                notifyOnLoginSuccess();
+                Boolean containsRequiredAuthority = verifyRequiredAuthority();
+
+                if (containsRequiredAuthority) {
+                    updateLoggedServer();
+                    getServerVersion();
+                    notifyOnLoginSuccess();
+                }
             }
 
             @Override
@@ -112,6 +128,28 @@ public class LoginUseCase implements UseCase {
                 notifyOnNetworkError();
                 return;
             }
+        }
+    }
+
+    private Boolean verifyRequiredAuthority() {
+        if (!credentials.isDemoCredentials()) {
+            Either<UserFailure, User> userResponse = userRepository.getCurrent();
+
+            if (userResponse.isLeft()) {
+                notifyOnNetworkError();
+                return false;
+            } else {
+                User user = ((Either.Right<User>) userResponse).getValue();
+
+                if (user.getAuthorities().contains(REQUIRED_AUTHORITY)) {
+                    return true;
+                } else {
+                    notifyRequiredAuthorityError(REQUIRED_AUTHORITY);
+                    return false;
+                }
+            }
+        } else {
+            return true;
         }
     }
 
@@ -172,6 +210,15 @@ public class LoginUseCase implements UseCase {
             @Override
             public void run() {
                 callback.onNetworkError();
+            }
+        });
+    }
+
+    private void notifyRequiredAuthorityError(String RequiredAuthority) {
+        mMainExecutor.run(new Runnable() {
+            @Override
+            public void run() {
+                callback.onRequiredAuthorityError(RequiredAuthority);
             }
         });
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoginUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoginUseCase.java
@@ -19,6 +19,8 @@
 
 package org.eyeseetea.malariacare.domain.usecase;
 
+import static org.eyeseetea.malariacare.domain.entity.UserKt.REQUIRED_AUTHORITY;
+
 import org.eyeseetea.malariacare.domain.boundary.IRepositoryCallback;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
@@ -66,8 +68,6 @@ public class LoginUseCase implements UseCase {
     private UserRepository userRepository;
     private Credentials credentials;
     private Callback callback;
-
-    private String REQUIRED_AUTHORITY = "F_IGNORE_TRACKER_REQUIRED_VALUE_VALIDATION";
 
     public LoginUseCase(IUserAccountRepository userAccountRepository,
             IServerRepository serverRepository,

--- a/app/src/main/java/org/eyeseetea/malariacare/factories/AuthenticationFactory.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/factories/AuthenticationFactory.kt
@@ -35,7 +35,7 @@ object AuthenticationFactory {
             serverLocalDataSource,
             serverRemoteDataSource
         )
-        val userRepository = UserD2ApiRepository();
+        val userRepository = UserD2ApiRepository()
 
         val serverRepository: IServerRepository = ServerFactory.provideServerRepository(context)
 

--- a/app/src/main/java/org/eyeseetea/malariacare/factories/AuthenticationFactory.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/factories/AuthenticationFactory.kt
@@ -5,6 +5,7 @@ import org.eyeseetea.malariacare.data.database.datasources.ServerInfoLocalDataSo
 import org.eyeseetea.malariacare.data.remote.api.ServerInfoRemoteDataSource
 import org.eyeseetea.malariacare.data.repositories.ServerInfoRepository
 import org.eyeseetea.malariacare.data.repositories.UserAccountRepository
+import org.eyeseetea.malariacare.data.repositories.UserD2ApiRepository
 import org.eyeseetea.malariacare.domain.boundary.repositories.IServerRepository
 import org.eyeseetea.malariacare.domain.boundary.repositories.IUserAccountRepository
 import org.eyeseetea.malariacare.domain.usecase.LoginUseCase
@@ -34,6 +35,7 @@ object AuthenticationFactory {
             serverLocalDataSource,
             serverRemoteDataSource
         )
+        val userRepository = UserD2ApiRepository();
 
         val serverRepository: IServerRepository = ServerFactory.provideServerRepository(context)
 
@@ -41,6 +43,7 @@ object AuthenticationFactory {
             userAccountRepository,
             serverRepository,
             serverInfoRepository,
+            userRepository,
             mainExecutor,
             asyncExecutor
         )

--- a/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
@@ -30,9 +30,11 @@ import org.eyeseetea.malariacare.data.database.iomodules.dhis.exporter.PushDataC
 import org.eyeseetea.malariacare.data.database.utils.Session;
 import org.eyeseetea.malariacare.data.remote.api.ServerInfoRemoteDataSource;
 import org.eyeseetea.malariacare.data.repositories.ServerInfoRepository;
+import org.eyeseetea.malariacare.data.repositories.UserD2ApiRepository;
 import org.eyeseetea.malariacare.domain.boundary.IPushController;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserRepository;
 import org.eyeseetea.malariacare.domain.usecase.PushUseCase;
 import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
@@ -81,9 +83,13 @@ public class PushService extends JobIntentService {
 
         IMainExecutor mainExecutor = new UIThreadExecutor();
         IAsyncExecutor asyncExecutor = new AsyncExecutor();
-        ServerInfoRemoteDataSource serverInfoRemoteDataSource = new ServerInfoRemoteDataSource(this);
+        ServerInfoRemoteDataSource serverInfoRemoteDataSource = new ServerInfoRemoteDataSource(
+                this);
         ServerInfoLocalDataSource serverInfoLocalDataSource = new ServerInfoLocalDataSource(this);
-        pushUseCase = new PushUseCase(pushController, mainExecutor, asyncExecutor, new ServerInfoRepository(serverInfoLocalDataSource, serverInfoRemoteDataSource));
+        UserRepository userRepository = new UserD2ApiRepository();
+        pushUseCase = new PushUseCase(pushController, mainExecutor, asyncExecutor,
+                new ServerInfoRepository(serverInfoLocalDataSource, serverInfoRemoteDataSource),
+                userRepository);
     }
 
     public void onPushFinished() {

--- a/app/src/main/java/org/eyeseetea/malariacare/strategies/LoginActivityStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/strategies/LoginActivityStrategy.java
@@ -100,6 +100,11 @@ public class LoginActivityStrategy {
                             }
 
                             @Override
+                            public void onRequiredAuthorityError(String authority) {
+                                Log.e(this.getClass().getSimpleName(), "Required Authority Error");
+                            }
+
+                            @Override
                             public void onUnsupportedServerVersion() {
                                 Log.e(this.getClass().getSimpleName(),
                                         "Unsupported Server Version");

--- a/app/src/main/java/org/eyeseetea/malariacare/strategies/PushServiceStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/strategies/PushServiceStrategy.java
@@ -96,7 +96,7 @@ public class PushServiceStrategy {
 
             @Override
             public void onInformativeError(String message) {
-                Log.e(TAG, "An error has occurred to the conversion in push process"+message);
+                Log.e(TAG, "An error has occurred to the conversion in push process" + message);
                 showInDialog(PreferencesState.getInstance().getContext().getString(
                         R.string.error_message), message);
             }
@@ -118,11 +118,20 @@ public class PushServiceStrategy {
                 launchServerVersionErrorAction();
                 Log.e(TAG, "onServerVersionError");
             }
+
+            @Override
+            public void onRequiredAuthorityError(String authority) {
+                AlarmPushReceiver.isDoneFail();
+                showInDialog(PreferencesState.getInstance().getContext().getString(
+                        R.string.error_message),
+                        PreferencesState.getInstance().getContext().getString(
+                                R.string.required_authority_error));
+            }
         });
     }
 
     public boolean showInDialog(String title, String message) {
-        if(DashboardActivity.dashboardActivity.isVisible()) {
+        if (DashboardActivity.dashboardActivity.isVisible()) {
             DashboardActivity.dashboardActivity.showException(title, message);
             return true;
         }
@@ -130,8 +139,8 @@ public class PushServiceStrategy {
     }
 
     public void launchServerVersionErrorAction() {
-       AlarmPushReceiver.cancelPushAlarm(DashboardActivity.dashboardActivity);
-        if(DashboardActivity.dashboardActivity.isVisible()){
+        AlarmPushReceiver.cancelPushAlarm(DashboardActivity.dashboardActivity);
+        if (DashboardActivity.dashboardActivity.isVisible()) {
             DashboardActivity.dashboardActivity.showInvalidServerDialog();
         }
     }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -284,4 +284,5 @@ clínica"</string>
 <string name="error_not_found">Servidor no encontrado.</string>
 
 <string name="network_error">"Hay un problema con la red. Por favor vuelve a intentarlo más tarde."</string>
+<string name="required_authority_error">"No tiene la autoridad requerida, comuníquese con su administrador."</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -277,4 +277,5 @@ Mensuelle"</string>
 <string name="error_not_found">Serveur introuvable.</string>
 
 <string name="network_error">"Il y a un problème avec le réseau, veuillez réessayer plus tard."</string>
+<string name="required_authority_error">"Vous ne disposez pas d'une autorisation requise, veuillez contacter votre administrateur."</string>
 </resources>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -292,4 +292,5 @@ evaluation"</string>
 
 
 <string name="network_error">"មានបញ្ហាជាមួយបណ្តាញសូមព្យាយាមម្តងទៀតនៅពេលក្រោយ។"</string>
+<string name="required_authority_error">"អ្នកមិនមានការអនុញ្ញាតដែលត្រូវការសូមទាក់ទងអ្នកគ្រប់គ្រងរបស់អ្នក."</string>
 </resources>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -290,4 +290,5 @@
 <string name="error_not_found">ບໍ່ພົບເຄື່ອງແມ່ຂ່າຍ.</string>
 
 <string name="network_error">"ມີປັນຫາກັບເຄືອຂ່າຍ, ກະລຸນາລອງ ໃໝ່ ໃນພາຍຫຼັງ."</string>
+<string name="required_authority_error">"ທ່ານບໍ່ມີໃບອະນຸຍາດທີ່ຕ້ອງການ, ກະລຸນາຕິດຕໍ່ຜູ້ເບິ່ງແຍງລະບົບຂອງທ່ານr."</string>
 </resources>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -249,4 +249,5 @@
 <string name="title_error_unexpected"></string>
 <string name="error_not_found"></string>
 <string name="network_error"></string>
+<string name="required_authority_error"></string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -270,4 +270,5 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="error_not_found">Servidor não encontrado.</string>
 
 <string name="network_error">"Há um problema com a rede, tente novamente mais tarde."</string>
+<string name="required_authority_error">"Você não tem uma autorização necessária, entre em contato com o seu administrador."</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -291,4 +291,5 @@ evaluation"</string>
 <string name="error_not_found">Server not found.</string>
 
 <string name="network_error">"There is a problem with the network, please try again later."</string>
+<string name="required_authority_error">"You don't have a required authority, please contact your administrator."</string>
 </resources>

--- a/app/src/test/java/org/eyeseetea/malariacare/domain/usecase/PushUseCaseTest.java
+++ b/app/src/test/java/org/eyeseetea/malariacare/domain/usecase/PushUseCaseTest.java
@@ -29,9 +29,13 @@ import org.eyeseetea.malariacare.domain.boundary.IPushController;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IServerInfoRepository;
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserFailure;
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserRepository;
+import org.eyeseetea.malariacare.domain.common.Either;
 import org.eyeseetea.malariacare.domain.entity.Credentials;
 import org.eyeseetea.malariacare.domain.entity.ServerInfo;
 import org.eyeseetea.malariacare.domain.common.ReadPolicy;
+import org.eyeseetea.malariacare.domain.entity.User;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -75,7 +79,14 @@ public class PushUseCaseTest {
             }
         };
 
-        PushUseCase pushUseCase = new PushUseCase(mPushController, mainExecutor, asyncExecutor, serverInfoRepository);
+        UserRepository userRepository = new UserRepository() {
+            @Override
+            public Either<UserFailure, User> getCurrent() {
+                return null;
+            }
+        };
+
+        PushUseCase pushUseCase = new PushUseCase(mPushController, mainExecutor, asyncExecutor, serverInfoRepository,userRepository);
 
         pushUseCase.execute(credentials, new PushUseCase.Callback() {
 
@@ -116,6 +127,11 @@ public class PushUseCaseTest {
 
             @Override
             public void onServerVersionError() {
+                callbackInvoked(false);
+            }
+
+            @Override
+            public void onRequiredAuthorityError(String authority) {
                 callbackInvoked(false);
             }
         });


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2453   
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature/verify_user_authority Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Show error message when trying to log in if the user does not have the authority "F_IGNORE_TRACKER_REQUIRED_VALUE_VALIDATION"

### :memo: How is it being implemented?

- Authorities by user does not exist in old SDK or hnqis data base, so I have created the infrastructure to retrieve user info using retrofit
- I have created a new user entity with authotity info
- I have created a user repository using retrofit
- I have modified the login use case to verify the required authority
- I have modified the push use case to verify the required authority

### :boom: How can it be tested?

**use case 1**: Enter in https://clone.psi-mis.org/ and remove the`_app - HNQIS` role  to the KEdemo1 user then  realize login against https://clone.psi-mis.org/ and the message `You don't have a required authority, please contact your administrator` should appear
**use case 2**: Enter in https://clone.psi-mis.org/ and add the `_app - HNQIS` role to the KEdemo1 user then realize login against https://clone.psi-mis.org/ and the login should work and realize the pull.
**use case 3**: Enter in https://clone.psi-mis.org/ and remove the`_app - HNQIS` role  to the KEdemo1 user then  realize login against https://clone.psi-mis.org/ and create a new survey and wait to push then the message `You don't have a required authority, please contact your administrator` should appear
**use case 4**: Enter in https://clone.psi-mis.org/ and add the `_app - HNQIS` role to the KEdemo1 user then  push should work

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

