### PR TITLE
Fix bug with authority changing the server

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/repositories/UserD2ApiRepository.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/repositories/UserD2ApiRepository.kt
@@ -13,7 +13,8 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 class UserD2ApiRepository : UserRepository {
 
-    private var userD2Api: UserD2Api? = null
+    private lateinit var userD2Api: UserD2Api
+    private var lastServerURL:String? = null
 
     init {
         initializeApi()
@@ -21,11 +22,9 @@ class UserD2ApiRepository : UserRepository {
 
     override fun getCurrent(): Either<UserFailure, User> {
         return try {
-            if (userD2Api == null) {
-                initializeApi()
-            }
+            initializeApi()
 
-            val userResponse = userD2Api?.getMe()?.execute()
+            val userResponse = userD2Api.getMe().execute()
 
             if (userResponse!!.isSuccessful && userResponse.body() != null) {
                 val user = userResponse.body()
@@ -40,12 +39,13 @@ class UserD2ApiRepository : UserRepository {
     }
 
     private fun initializeApi() {
+
         val credentials = PreferencesState.getInstance().creedentials
 
-        if (credentials != null) {
+        if (credentials != null && credentials.serverURL != lastServerURL) {
             val authInterceptor = BasicAuthInterceptor(credentials.username, credentials.password)
 
-            val retrofit: Retrofit = Retrofit.Builder()
+            val retrofit = Retrofit.Builder()
                 .addConverterFactory(GsonConverterFactory.create())
                 .client(
                     OkHttpClient.Builder()
@@ -55,6 +55,7 @@ class UserD2ApiRepository : UserRepository {
                 .build()
 
             userD2Api = retrofit.create(UserD2Api::class.java)
+            lastServerURL = credentials.serverURL
         }
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/repositories/UserD2ApiRepository.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/repositories/UserD2ApiRepository.kt
@@ -14,7 +14,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 class UserD2ApiRepository : UserRepository {
 
     private lateinit var userD2Api: UserD2Api
-    private var lastServerURL:String? = null
+    private var lastServerURL: String? = null
 
     init {
         initializeApi()


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://app.clickup.com/t/caxf1t   
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: fix/bug_with_authority_changing_of_server Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

the problem was that the api service (Retrofit) was not recreated when the url change, the solution is to recreate retrofit and api service when the server url and last server url are different

### :memo: How is it being implemented?

- I have modified UserD2ApiRepository to recreate api service when is necessary

### :boom: How can it be tested?

#### Case 1
1. Try to login with the following credentials: server (https://clone.psi-mis.org), user(KEdemo1), password (Kenyademo1!)
You should not be able to log in.
2. Change server to https://data.psi-mis.org
3. You should be able to log in.
#### Case 2
1. Login with the following credentials: server (https://data.psi-mis.org), user(KEdemo1), password (Kenyademo1!)
2. You should be able to log in
3. Log out
4. Login with the following credentials: server (https://clone.psi-mis.org), user(KEdemo1), password (Kenyademo1!)
5. You should not be able to log in

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

