### PR TITLE
Add api version to fix authority bug in 2.30 servers

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/d2api/UserD2Api.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/d2api/UserD2Api.kt
@@ -5,6 +5,6 @@ import retrofit2.Call
 import retrofit2.http.GET
 
 interface UserD2Api {
-    @GET("api/me?fields=id,name,authorities")
+    @GET("api/30/me?fields=id,name,authorities")
     fun getMe(): Call<User>
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://app.clickup.com/t/fn3g01 
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: fix/bug_with_authorities_in_2_30_servers Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Login against https://sm-dev.hnqis.org does not work

### :memo: How is it being implemented?

The problem is that https://sm-dev.hnqis.org is a 2:30 server and this url does not return authorities:
https://sm-dev.hnqis.org/api/me.json?fields=id,name,authorities

In the data server, this url works returning the authorities (it's a 2:33 version)
https://data.psi-mis.org/api/me?fields=id,name,authorities

Adding /api/30 works  for both 

https://sm-dev.hnqis.org/api/30/me.json?fields=id,name,authorities
https://data.psi-mis.org/api/30/me?fields=id,name,authorities

- I have modified url to retrieve the authorities of a user adding API version 30. 

### :boom: How can it be tested?

**Use case 1**: Login against https://sm-dev.hnqis.org should work
**Use case 2**: Login against https://data.psi-mis.org should work

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-