### PR TITLE
Change the authority error message

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -284,5 +284,5 @@ clínica"</string>
 <string name="error_not_found">Servidor no encontrado.</string>
 
 <string name="network_error">"Hay un problema con la red. Por favor vuelve a intentarlo más tarde."</string>
-<string name="required_authority_error">"No tiene la autoridad requerida, comuníquese con su administrador."</string>
+<string name="required_authority_error">"El rol de usuario de HQIS no está habilitado. Por favor contacte a su administrador."</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -277,5 +277,5 @@ Mensuelle"</string>
 <string name="error_not_found">Serveur introuvable.</string>
 
 <string name="network_error">"Il y a un problème avec le réseau, veuillez réessayer plus tard."</string>
-<string name="required_authority_error">"Vous ne disposez pas d'une autorisation requise, veuillez contacter votre administrateur."</string>
+<string name="required_authority_error">"Le rôle d'utilisateur HNQIS n'est pas activé. Veuillez contacter votre administrateur."</string>
 </resources>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -292,5 +292,5 @@ evaluation"</string>
 
 
 <string name="network_error">"មានបញ្ហាជាមួយបណ្តាញសូមព្យាយាមម្តងទៀតនៅពេលក្រោយ។"</string>
-<string name="required_authority_error">"អ្នកមិនមានការអនុញ្ញាតដែលត្រូវការសូមទាក់ទងអ្នកគ្រប់គ្រងរបស់អ្នក."</string>
+<string name="required_authority_error">"តួនាទីអ្នកប្រើ HNQIS មិនត្រូវបានអនុញ្ញាត។ សូមទាក់ទងអ្នកគ្រប់គ្រងរបស់អ្."</string>
 </resources>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -290,5 +290,5 @@
 <string name="error_not_found">ບໍ່ພົບເຄື່ອງແມ່ຂ່າຍ.</string>
 
 <string name="network_error">"ມີປັນຫາກັບເຄືອຂ່າຍ, ກະລຸນາລອງ ໃໝ່ ໃນພາຍຫຼັງ."</string>
-<string name="required_authority_error">"ທ່ານບໍ່ມີໃບອະນຸຍາດທີ່ຕ້ອງການ, ກະລຸນາຕິດຕໍ່ຜູ້ເບິ່ງແຍງລະບົບຂອງທ່ານr."</string>
+<string name="required_authority_error">"ບົດບາດຂອງຜູ້ໃຊ້ HNQIS ບໍ່ຖືກເປີດໃຊ້ງານ. ກະລຸນາຕິດຕໍ່ຜູ້ເບິ່ງແຍງລະບົບຂອງທ່ານ."</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -270,5 +270,5 @@ Passo 2: Localize a ID do paciente de 1) no Registo de Farmácia e anote se rece
 <string name="error_not_found">Servidor não encontrado.</string>
 
 <string name="network_error">"Há um problema com a rede, tente novamente mais tarde."</string>
-<string name="required_authority_error">"Você não tem uma autorização necessária, entre em contato com o seu administrador."</string>
+<string name="required_authority_error">"Função de usuário HNQIS não habilitada. Entre em contato com o seu administrador."</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -291,5 +291,5 @@ evaluation"</string>
 <string name="error_not_found">Server not found.</string>
 
 <string name="network_error">"There is a problem with the network, please try again later."</string>
-<string name="required_authority_error">"You don't have a required authority, please contact your administrator."</string>
+<string name="required_authority_error">"HNQIS user role not enabled. Please contact your administrator."</string>
 </resources>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://app.clickup.com/t/fn3g2y
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature/change_authority_message Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Change the authority error message to `HNQIS user role not enabled. Please contact your administrator` 

### :memo: How is it being implemented?

Changing the resource string file for every language.

### :boom: How can it be tested?

**Use case 1**: The authority error message should be the expected

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-