### PR TITLE
Change learning center url

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -172,7 +172,7 @@
     <string name="server_version_preference" translatable="false">server_version_preference</string>
     <string name="is_server_version_supported" translatable="false">is_server_version_supported</string>
     <string name="google_play_url" translatable="false">"https://play.google.com/store/apps/details?id=org.eyeseetea.malariacare.hnqis_ng"</string>
-    <string name="learning_center_url">https://psiorg.sharepoint.com/sites/us_gbs_comms/SitePages/HNQIS-Learning-Center.aspx</string>
+    <string name="learning_center_url">https://psiorg.sharepoint.com/sites/DigitalHealth/SitePages/HNQIS-Learning-Center.aspx</string>
     <string name="submit_ticket_url">https://helppsi.freshdesk.com/en/support/tickets/new</string>
 
 </resources>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://app.clickup.com/t/jq6bc2
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature/change_learning_center_url Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/migrate_to_android_x 
**SDK**: 
       Origin: feature/migrate_to_android_x

### :tophat: What is the goal?

Change URL for "HNQIS learning center"

### :memo: How is it being implemented?
- [x] Change URL for "HNQIS learning center"

### :boom: How can it be tested?

**Use case 1**:  The url for the learning center should work

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-