### PR TITLE
Remove A,B,C from pie chart labels

### DIFF
--- a/app/src/main/assets/dashboard/js/competencies/CompetenciesPieChartBuilder.js
+++ b/app/src/main/assets/dashboard/js/competencies/CompetenciesPieChartBuilder.js
@@ -31,19 +31,19 @@ class CompetenciesPieChartBuilder{
             [{
                 value: data.valueA,
                 color: classificationContext.colors.competentColor,
-                label: "A (" + classificationContext.texts.competentText + ")"
+                label: classificationContext.texts.competentText
             }, {
                 value: data.valueB,
                 color: classificationContext.colors.competentImprovementColor,
-                label: "B (" + classificationContext.texts.competentImprovementText + ")"
+                label: classificationContext.texts.competentImprovementText
             }, {
                 value: data.valueC,
                 color: classificationContext.colors.notCompetentColor,
-                label: "C (" + classificationContext.texts.notCompetentText + ")"
+                label: classificationContext.texts.notCompetentText
             }, {
                 value: data.valueNA,
                 color: classificationContext.colors.notAvailableColor,
-                label: "" + classificationContext.texts.notAvailableText + ""
+                label: classificationContext.texts.notAvailableText
             }],
             {
                 tooltipTemplate: "<%= value %>",


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/jvb01a
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: ffeature/Change_monitor_pie_chart_labels Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/migrate_to_android_x 
**SDK**: 
       Origin: feature/migrate_to_android_x

### :tophat: What is the goal?

Change monitor pie chart labels according to classification

### :memo: How is it being implemented?
- [x] Remove A,B,C from pie chart labels

![device-2021-05-18-090136](https://user-images.githubusercontent.com/5593590/118607419-d5935480-b7b8-11eb-98be-d569d19325db.png)


### :boom: How can it be tested?

**Use case 1**:  Tne pie char legends for component classification should not have A,B,C

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-