### PR TITLE
Send server as user property to analytics

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         tools:node="remove" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 

--- a/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
@@ -73,6 +73,7 @@ import org.eyeseetea.malariacare.factories.AuthenticationFactory;
 import org.eyeseetea.malariacare.factories.ServerFactory;
 import org.eyeseetea.malariacare.layout.adapters.general.ServerArrayAdapter;
 import org.eyeseetea.malariacare.layout.utils.LayoutUtils;
+import org.eyeseetea.malariacare.presentation.analytics.AnalyticsReportKt;
 import org.eyeseetea.malariacare.presentation.bugs.BugReportKt;
 import org.eyeseetea.malariacare.presentation.presenters.LoginPresenter;
 import org.eyeseetea.malariacare.strategies.LoginActivityStrategy;
@@ -140,11 +141,13 @@ public class LoginActivity extends Activity implements LoginPresenter.View {
                 Server server = ((Either.Right<Server>) serverResult).getValue();
 
                 BugReportKt.addServerAndUser(server.getUrl(),loggedUser.getUsername());
+                AnalyticsReportKt.addServer(this,server.getUrl());
                 launchActivity(LoginActivity.this, DashboardActivity.class);
             });
         } else {
             ProgressActivity.PULL_CANCEL = false;
             BugReportKt.removeServerAndUser();
+            AnalyticsReportKt.removeServer(this);
 
             initViews();
             initPresenter();

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/analytics/AnalyticsReport.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/analytics/AnalyticsReport.kt
@@ -1,0 +1,19 @@
+package org.eyeseetea.malariacare.presentation.analytics
+
+import android.content.Context
+import android.util.Log
+import com.google.firebase.analytics.FirebaseAnalytics
+
+private const val serverKey: String = "server"
+private const val logPrefix: String = "AnalyticsReport"
+
+
+fun addServer(context: Context, server: String) {
+    FirebaseAnalytics.getInstance(context).setUserProperty(serverKey, server)
+    Log.d("$logPrefix.$serverKey", server)
+}
+
+fun removeServer(context: Context) {
+    FirebaseAnalytics.getInstance(context).setUserProperty(serverKey, "")
+    Log.d("$logPrefix.$serverKey", "")
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/analytics/AnalyticsReport.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/analytics/AnalyticsReport.kt
@@ -7,7 +7,6 @@ import com.google.firebase.analytics.FirebaseAnalytics
 private const val serverKey: String = "server"
 private const val logPrefix: String = "AnalyticsReport"
 
-
 fun addServer(context: Context, server: String) {
     FirebaseAnalytics.getInstance(context).setUserProperty(serverKey, server)
     Log.d("$logPrefix.$serverKey", server)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/m3bbc6
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature/firebase_analytics_send_user_properties Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Filter reports in firebase by the server (crashlytics and analytics)

### :memo: How is it being implemented?
- [x] Send user property server to analytics
- [x] Add android.permission.WAKE_LOCK, this is necessary to send user properties by analytics instance

I have investigated crashlytics to filter by sent keys from the app.  We have several options:

- from dashboard page we can filter by bugs with specific key name

<img width="1911" alt="Captura de pantalla 2021-06-10 a las 17 16 21" src="https://user-images.githubusercontent.com/5593590/121668492-a1efd580-caab-11eb-9343-b5f7a43c62da.png">

- from the bug page, we can filter the events of a bug using key-value

<img width="1920" alt="Captura de pantalla 2021-06-10 a las 17 09 43" src="https://user-images.githubusercontent.com/5593590/121668812-f6935080-caab-11eb-8696-cee901abb868.png">

I have investigated analytics to filter by sent keys in crashlytics and this is not possible. We need to send new info from the app for analytics.
I think the best option for us is to send a new server user property, then we can filter in the dashboard and for events using server user property.
<img width="1914" alt="Captura de pantalla 2021-06-11 a las 11 58 22" src="https://user-images.githubusercontent.com/5593590/121669243-699cc700-caac-11eb-8186-e30ac9978275.png">

<img width="1919" alt="Captura de pantalla 2021-10-11 a las 9 23 40" src="https://user-images.githubusercontent.com/5593590/136749499-32bcb0f5-6b0b-4bbe-b548-408d4fb5f573.png">


**important**: in the firebase console is necessary to create a new custom dimension from the custom definitions menu in the sidebar. The new dimension must be to have as user property server. I have created it in debug firebase but we need to create it in production firebase.

### :boom: How can it be tested?

**Use case 1**:  should send server user property to the analytics

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots

