### PR TITLE
Feature/crashlytics crashes without server and user

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/BaseActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/BaseActivity.java
@@ -423,6 +423,7 @@ public abstract class BaseActivity extends AppCompatActivity {
         mLogoutUseCase.execute(new LogoutUseCase.Callback() {
             @Override
             public void onLogoutSuccess() {
+                AlarmPushReceiver.cancelPushAlarm(BaseActivity.this);
                 finishAndGo(LoginActivity.class);
             }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
@@ -140,7 +140,10 @@ public class LoginActivity extends Activity implements LoginPresenter.View {
             getServerUseCase.execute(serverResult -> {
                 Server server = ((Either.Right<Server>) serverResult).getValue();
 
-                BugReportKt.addServerAndUser(server.getUrl(),loggedUser.getUsername());
+                if (server.getUrl() != null && loggedUser.getUsername() != null){
+                    BugReportKt.addServerAndUser(server.getUrl(),loggedUser.getUsername());
+                }
+
                 AnalyticsReportKt.addServer(this,server.getUrl());
                 launchActivity(LoginActivity.this, DashboardActivity.class);
             });

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/FiltersFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/FiltersFragment.java
@@ -1,7 +1,9 @@
 package org.eyeseetea.malariacare.fragments;
 
+import android.content.Context;
 import android.os.Bundle;
 import androidx.annotation.IdRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
@@ -28,8 +30,8 @@ public abstract class FiltersFragment extends Fragment implements IModuleFragmen
     }
 
     @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
 
         initializeFilters();
     }
@@ -60,21 +62,23 @@ public abstract class FiltersFragment extends Fragment implements IModuleFragmen
             orgUnitProgramFilterView.setFilterType(getFilterType());
         }
 
-        orgUnitProgramFilterView.setFilterChangedListener(
-                new OrgUnitProgramFilterView.FilterChangedListener() {
-                    @Override
-                    public void onProgramFilterChanged(String selectedProgramFilter) {
-                        saveCurrentFilters();
-                        onFiltersChanged();
+        if (orgUnitProgramFilterView != null){
+            orgUnitProgramFilterView.setFilterChangedListener(
+                    new OrgUnitProgramFilterView.FilterChangedListener() {
+                        @Override
+                        public void onProgramFilterChanged(String selectedProgramFilter) {
+                            saveCurrentFilters();
+                            onFiltersChanged();
 
-                    }
+                        }
 
-                    @Override
-                    public void onOrgUnitFilterChanged(String selectedOrgUnitFilter) {
-                        saveCurrentFilters();
-                        onFiltersChanged();
-                    }
-                });
+                        @Override
+                        public void onOrgUnitFilterChanged(String selectedOrgUnitFilter) {
+                            saveCurrentFilters();
+                            onFiltersChanged();
+                        }
+                    });
+        }
     }
 
     private void saveCurrentFilters() {

--- a/app/src/main/java/org/eyeseetea/malariacare/strategies/PushServiceStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/strategies/PushServiceStrategy.java
@@ -131,7 +131,7 @@ public class PushServiceStrategy {
     }
 
     public boolean showInDialog(String title, String message) {
-        if (DashboardActivity.dashboardActivity.isVisible()) {
+        if (DashboardActivity.dashboardActivity != null && DashboardActivity.dashboardActivity.isVisible()) {
             DashboardActivity.dashboardActivity.showException(title, message);
             return true;
         }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/qtj6z4
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature/crashlytics_crahes Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Analyze crashes without user and server in Crashlytics and ty solve it.

### :memo: How is it being implemented?
- [x] Fix filters fragment NullPointerException
- [x] Fix NullPointerException to show dialog exception
- [x] Cancel push alarm when logout is realized
- [x] Protect against nulls to configure Crashlytics user and server



### :boom: How can it be tested?

I have not reproduced any crash in this issue but analyzing stack trace from Crashlytics I have implemented fixes in the code

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots
