### PR TITLE
Fix/put event in 2.36

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -25,9 +25,12 @@ import android.location.Location;
 import android.os.Build;
 import android.util.Log;
 
+import com.raizlabs.android.dbflow.sql.language.Select;
+
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.models.DataValueExtended;
 import org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.models.EventExtended;
+import org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.models.ProgramStageExtended;
 import org.eyeseetea.malariacare.data.database.model.CompositeScoreDB;
 import org.eyeseetea.malariacare.data.database.model.ObservationDB;
 import org.eyeseetea.malariacare.data.database.model.ObservationValueDB;
@@ -57,6 +60,8 @@ import org.eyeseetea.malariacare.layout.score.ScoreRegister;
 import org.eyeseetea.malariacare.utils.AUtils;
 import org.eyeseetea.malariacare.utils.Constants;
 import org.eyeseetea.malariacare.utils.DateParser;
+import org.hisp.dhis.client.sdk.android.api.persistence.flow.EventFlow;
+import org.hisp.dhis.client.sdk.android.api.persistence.flow.EventFlow_Table;
 import org.joda.time.DateTime;
 
 import java.util.ArrayList;
@@ -370,7 +375,10 @@ public class ConvertToSDKVisitor implements
         currentEvent.setStatus(EventExtended.STATUS_COMPLETED);
         currentEvent.setOrganisationUnitId(currentSurvey.getOrgUnit().getUid());
         currentEvent.setProgramId(currentSurvey.getProgram().getUid());
-        currentEvent.setProgramStageId(currentSurvey.getProgram().getUid());
+
+        currentEvent.setProgramStageId(
+                ProgramStageExtended.getProgramStageUid(currentSurvey.getProgram().getUid()));
+
         updateEventLocation();
         Log.d(TAG, "Saving event " + currentEvent.getUid());
         return currentEvent;
@@ -384,7 +392,8 @@ public class ConvertToSDKVisitor implements
         currentEvent.setStatus(EventExtended.STATUS_COMPLETED);
         currentEvent.setOrganisationUnitId(currentSurvey.getOrgUnit().getUid());
         currentEvent.setProgramId(currentSurvey.getProgram().getUid());
-        currentEvent.setProgramStageId(currentSurvey.getProgram().getUid());
+        currentEvent.setProgramStageId(
+                ProgramStageExtended.getProgramStageUid(currentSurvey.getProgram().getUid()));
         Log.d(TAG, "Saving event " + currentEvent.getUid());
         return currentEvent;
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/importer/models/ProgramStageExtended.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/importer/models/ProgramStageExtended.java
@@ -104,4 +104,13 @@ public class ProgramStageExtended implements VisitableFromSDK {
         }
         return extendedsList;
     }
+
+    public static String getProgramStageUid(String programUid) {
+        ProgramStageFlow programStage =  new Select()
+                .from(ProgramStageFlow.class)
+                .where(ProgramStageFlow_Table.program.eq(programUid))
+                .querySingle();
+
+        return programStage.getUId();
+    }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/9xwf23
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: /fix/put_event_in_2_3_6 target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Review endpoints against a 2.36 server

### :memo: How is it being implemented?
- [x] Test all features of the app
- [x] Fix put event request executed to create observations and action plan

The problem is that we was sending as program stage the program for the event

The testing has been realized with the user KEdemo1 and server https://236data.psi-mis.org/
Endpoints tested:
#### Pull (OK)
* https://236data.psi-mis.org/api/system/info/
* https://236data.psi-mis.org/api/30/me?fields=id,created,lastUpdated,name,displayName,firstName,surname,gender,birthday,introduction,education,employer,interests,jobTitle,languages,email,phoneNumber,organisationUnits[id,programs[id,programType]],userCredentials[userRoles], programs, dataSets
* https://236data.psi-mis.org/api/organisationUnitLevels?fields=id%2CdisplayName%2Clevel&paging=false
* https://236data.psi-mis.org/api/attributes?fields=id%2Cname%2CdisplayName%2Ccreated%2ClastUpdated%2Ccode%2CvalueType&paging=false
* https://236data.psi-mis.org/api/organisationUnits?fields=id,name,coordinates,displayName,created,lastUpdated,access,path,level,openingDate,programs[id],dataSets[id],attributeValues[*,attribute[name,displayName,created,lastUpdated,access,id,valueType,code]]&paging=false&filter=id:in:[ijCMzF0Ij9E,Cf1y95PndAB,A5HZNrJc2ir]
https://236data.psi-mis.org/api/programs?fields=id,name,displayName,created,lastUpdated,access,attributeValues[*,attribute[id,code]],version,programType,organisationUnits[id],trackedEntity[id,name,displayName,created,lastUpdated,access],programTrackedEntityAttributes[id,name,displayName,created,lastUpdated,access,mandatory,displayShortName,externalAccess,valueType,allowFutureDate,displayInList,program[id],trackedEntityAttribute[id,name,displayName,created,lastUpdated,access,unique,programScope,orgunitScope,displayInListNoProgram,displayOnVisitSchedule,externalAccess,valueType,confidential,inherit,sortOrderVisitSchedule,dimension,sortOrderInListNoProgram,optionSet[id,name,displayName,created,lastUpdated,access,version,options[id,name,displayName,created,lastUpdated,access,code]]]],displayFrontPageList,useFirstStageDuringRegistration,selectEnrollmentDatesInFuture,incidentDateLabel,selectIncidentDatesInFuture,onlyEnrollOnce,enrollmentDateLabel,ignoreOverdueEvents,displayIncidentDate,withoutRegistration,registration,relationshipFromA,programStages[id,name,displayName,created,lastUpdated,access,dataEntryType,blockEntryForm,reportDateDescription,executionDateLabel,displayGenerateEventBox,description,externalAccess,openAfterEnrollment,captureCoordinates,defaultTemplateMessage,remindCompleted,validCompleteOnly,sortOrder,generatedByEnrollmentDate,preGenerateUID,autoGenerateEvent,allowGenerateNextVisit,repeatable,minDaysFromStart,program[id],programStageSections[id,name,displayName,created,lastUpdated,access,sortOrder,programStage[id],dataElements[id]],programStageDataElements[id,name,displayName,created,lastUpdated,access,programStage[id],allowFutureDate,sortOrder,displayInReports,allowProvidedElsewhere,compulsory,dataElement[code,description,attributeValues[*,attribute[id,code]],id,name,displayName,created,lastUpdated,accessshortName,valueType,zeroIsSignificant,aggregationOperator,formName,numberType,domainType,dimension,displayFormName,optionSet[id,name,displayName,created,lastUpdated,access,version,options[id,name,displayName,created,lastUpdated,access,code]]]]]&paging=false&filter=id:in:[Qt74wJNHTAS,TPW9xYrV8i8,qb6IfcDal3r,Wps8E2P8P9S,XRqyZbWDgWl,Emzrjjdcfcq,mZ0zJcGODwD,u6pCofOY3O7,ggxhuvMBtxj,viBtnUfo7Wk]
* https://236data.psi-mis.org/api/programStages?fields=id%2CdisplayName&paging=false
* https://236data.psi-mis.org/api/programStageSections?fields=id%2CdataElements%5Bid%5D&paging=false
* https://236data.psi-mis.org/api/programs?fields=programStages[programStageDataElements[id]]&paging=false
* https://236data.psi-mis.org/api/dataElements?fields=id,displayName&paging=false
* https://236data.psi-mis.org/api/optionSets?fields=id,name,displayName,created,lastUpdated,access,version,options[id,name,displayName,created,lastUpdated,access,code,attributeValues[*,attribute[id,code]]]&paging=false
* https://236data.psi-mis.org/api/programRules?fields=id&paging=false
* https://236data.psi-mis.org/api/programRules?fields=id,name,displayName,created,lastUpdated,access,condition,externalAccess,description,program[id],programStage[id],priority,programRuleActions[id,name,displayName,created,lastUpdated,access,programRuleActionType,programRule[id],programStage[id],programStageSection[id],programIndicator[id],trackedEntityAttribute[id],dataElement[id],content,location,data]&paging=false&filter=program.id:in:[Qt74wJNHTAS,TPW9xYrV8i8,Wps8E2P8P9S,qb6IfcDal3r,XRqyZbWDgWl,Emzrjjdcfcq,mZ0zJcGODwD,u6pCofOY3O7,ggxhuvMBtxj,viBtnUfo7Wk]
* https://236data.psi-mis.org/api/programRuleActions?fields=id&paging=false
* https://236data.psi-mis.org/api/programRuleVariables?fields=id&paging=false
* https://236data.psi-mis.org/api/programRuleVariables?fields=id,name,displayName,created,lastUpdated,access,programRuleVariableSourceType,program[id],programStage[id],dataElement[id],trackedEntityAttribute[id]&paging=false&filter=program.id:in:[Qt74wJNHTAS,TPW9xYrV8i8,Wps8E2P8P9S,qb6IfcDal3r,XRqyZbWDgWl,Emzrjjdcfcq,mZ0zJcGODwD,u6pCofOY3O7,ggxhuvMBtxj,viBtnUfo7Wk]
* https://236data.psi-mis.org/api/events?program={programId}&startDate=2020-10-06&fields=event,name,displayName,created,lastUpdated,access,program,programStage,status,orgUnit,eventDate,dueDate,coordinate,dataValues&orgUnit=A5HZNrJc2ir&maxEvents=30

#### Push surveys(OK)
POST https://236data.psi-mis.org/api/events

#### Push observation and action plan (FAIL- 409 conflict)

PUT https://236data.psi-mis.org/api/events
Sending added Observations and Action plan to the survey (FAIL- 409 conflict)

 Response
```json
{
    "httpStatus": "Conflict",
    "httpStatusCode": 409,
    "status": "WARNING",
    "message": "One more conflicts encountered, please check import summary.",
    "response": {
        "responseType": "ImportSummary",
        "status": "WARNING",
        "importOptions": {
            "idSchemes": {},
            "dryRun": false,
            "async": false,
            "importStrategy": "CREATE_AND_UPDATE",
            "mergeMode": "REPLACE",
            "reportMode": "FULL",
            "skipExistingCheck": false,
            "sharing": false,
            "skipNotifications": false,
            "skipAudit": false,
            "datasetAllowsPeriods": false,
            "strictPeriods": false,
            "strictDataElements": false,
            "strictCategoryOptionCombos": false,
            "strictAttributeOptionCombos": false,
            "strictOrganisationUnits": false,
            "requireCategoryOptionCombo": false,
            "requireAttributeOptionCombo": false,
            "skipPatternValidation": false,
            "ignoreEmptyCollection": false,
            "force": false,
            "firstRowIsHeader": true,
            "skipLastUpdated": false,
            "mergeDataValues": false,
            "skipCache": false
        },
        "description": "Data Values [rcAkFQFYknk,fFBBXYbUDr7,OJRW4LPDsdU,k5b1GT20fk0,uv22UMpXUA2,CttsWye5Gu5,xWUdeVU4JAr,iVNzYd5Cz5C,zAWljfTXSnZ,KesgQ5NHkQW,OoTtQGOoq1N,ggrkfoq6nxA,Ntwf6HeYTUO,RoKnpjq5yI3,bVPpgPm1hj0,FEkGksxhOpH,TgCWRlUXbca,hUXusK1q7qX,GSEmnBELzB2,arl6RRtsZQ8,Qor2Meb1sNf,Y8Nmpp7RhXw,vGphb9ZfLGg,M93RYt47CMK,wRaxfSNz5Xb,y88IXJ7l8da,I7rMklpweh0,SQqeXOp8M3d,zckZqXOQRHT,DBUwlPCO0Hd,Nr9wc53FAO9,z9bskG067HE,UzOOxp9OlSb,YVyeP6WQkDA,BtReGP2EMKA,VIFKfFTVLcg,B6afQk2qZTL,SNoQ2dEPfBU] ignored because not defined in program stage u6pCofOY3O7",
        "importCount": {
            "imported": 1,
            "updated": 0,
            "ignored": 0,
            "deleted": 0
        },
        "conflicts": [],
        "reference": "urkFUI6mjuG"
    }
}
```

I have used the Android Studio profiler and traces in logcat to review endpoints

<img width="1920" alt="Captura de pantalla 2021-10-07 a las 10 35 31" src="https://user-images.githubusercontent.com/5593590/136351072-1fe4a6bc-ed36-4760-aad6-1c9e9771ce3c.png">


### :boom: How can it be tested?

To test the fix, create a survey and observations and actions plan. The push should work.

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots
