### PR TITLE
Fix top crashes

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
@@ -44,6 +44,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import androidx.annotation.Nullable;
+
 public class PreferencesState {
 
     static Context context;
@@ -533,6 +535,7 @@ public class PreferencesState {
         return locale.getLanguage().substring(0, 2);
     }
 
+    @Nullable
     public Credentials getCreedentials() {
         return creedentials;
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/ServerRemoteDataSource.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/ServerRemoteDataSource.kt
@@ -50,7 +50,7 @@ class ServerRemoteDataSource(private val poEditorApiClient: PoEditorApiClient) :
 
             val response = OkHttpClientDataSource.executeCall(
                 BasicAuthenticator(credentials),
-                credentials.serverURL, SERVER_VERSION_CALL
+                credentials!!.serverURL, SERVER_VERSION_CALL
             )
             val jsonNode = OkHttpClientDataSource.parseResponse(response.body()!!.string())
             val keyFlag = jsonNode[KEY_FLAG_FIELD].asText()

--- a/app/src/main/java/org/eyeseetea/malariacare/data/repositories/UserDemoRepository.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/repositories/UserDemoRepository.kt
@@ -1,0 +1,22 @@
+package org.eyeseetea.malariacare.data.repositories
+
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserFailure
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserRepository
+import org.eyeseetea.malariacare.domain.common.Either
+import org.eyeseetea.malariacare.domain.entity.Credentials
+import org.eyeseetea.malariacare.domain.entity.REQUIRED_AUTHORITY
+import org.eyeseetea.malariacare.domain.entity.User
+
+class UserDemoRepository : UserRepository {
+
+    override fun getCurrent(): Either<UserFailure, User> {
+        val demoCredentials = Credentials.createDemoCredentials()
+        return Either.Right(
+            User(
+                demoCredentials.username,
+                demoCredentials.username,
+                listOf(REQUIRED_AUTHORITY)
+            )
+        )
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/factories/AuthenticationFactory.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/factories/AuthenticationFactory.kt
@@ -2,12 +2,15 @@ package org.eyeseetea.malariacare.factories
 
 import android.content.Context
 import org.eyeseetea.malariacare.data.database.datasources.ServerInfoLocalDataSource
+import org.eyeseetea.malariacare.data.database.utils.PreferencesState
 import org.eyeseetea.malariacare.data.remote.api.ServerInfoRemoteDataSource
 import org.eyeseetea.malariacare.data.repositories.ServerInfoRepository
 import org.eyeseetea.malariacare.data.repositories.UserAccountRepository
 import org.eyeseetea.malariacare.data.repositories.UserD2ApiRepository
+import org.eyeseetea.malariacare.data.repositories.UserDemoRepository
 import org.eyeseetea.malariacare.domain.boundary.repositories.IServerRepository
 import org.eyeseetea.malariacare.domain.boundary.repositories.IUserAccountRepository
+import org.eyeseetea.malariacare.domain.boundary.repositories.UserRepository
 import org.eyeseetea.malariacare.domain.usecase.LoginUseCase
 import org.eyeseetea.malariacare.domain.usecase.LogoutUseCase
 import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor
@@ -35,7 +38,7 @@ object AuthenticationFactory {
             serverLocalDataSource,
             serverRemoteDataSource
         )
-        val userRepository = UserD2ApiRepository()
+        val userRepository = provideUserRepository()
 
         val serverRepository: IServerRepository = ServerFactory.provideServerRepository(context)
 
@@ -55,6 +58,16 @@ object AuthenticationFactory {
         return LogoutUseCase(mUserAccountRepository)
     }
 
+    fun provideUserRepository(): UserRepository {
+        return if (!PreferencesState.getInstance().creedentials.isDemoCredentials)
+            UserD2ApiRepository()
+        else
+            UserDemoRepository()
+    }
+
     private fun provideUserAccountRepository(context: Context) =
         UserAccountRepository(context)
+
+
 }
+

--- a/app/src/main/java/org/eyeseetea/malariacare/factories/AuthenticationFactory.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/factories/AuthenticationFactory.kt
@@ -59,10 +59,12 @@ object AuthenticationFactory {
     }
 
     fun provideUserRepository(): UserRepository {
-        return if (!PreferencesState.getInstance().creedentials.isDemoCredentials)
-            UserD2ApiRepository()
-        else
+        return if (PreferencesState.getInstance().creedentials != null &&
+            PreferencesState.getInstance().creedentials!!.isDemoCredentials)
             UserDemoRepository()
+        else
+            UserD2ApiRepository()
+
     }
 
     private fun provideUserAccountRepository(context: Context) =

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/CreateSurveyFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/CreateSurveyFragment.java
@@ -610,7 +610,10 @@ public class CreateSurveyFragment extends Fragment {
             for (OrgUnitDB orgUnit : selectedHierarchy) {
                 orgUnitList += orgUnit.getUid() + TOKEN;
             }
-            orgUnitList=orgUnitList.substring(0,orgUnitList.lastIndexOf(TOKEN));
+
+            if (orgUnitList.lastIndexOf(TOKEN) != -1){
+                orgUnitList=orgUnitList.substring(0,orgUnitList.lastIndexOf(TOKEN));
+            }
 
             saveOrgUnitList(orgUnitList);
             return orgUnitList;

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/PlanModuleController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/PlanModuleController.java
@@ -26,13 +26,13 @@ import android.view.View;
 import org.eyeseetea.malariacare.DashboardActivity;
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
+import org.eyeseetea.malariacare.fragments.IModuleFragment;
 import org.eyeseetea.malariacare.fragments.PlannedFragment;
 import org.eyeseetea.malariacare.fragments.PlannedPerOrgUnitFragment;
 import org.eyeseetea.malariacare.layout.dashboard.config.ModuleSettings;
 
 public class PlanModuleController extends ModuleController {
     private static final String TAG = ".PlanModuleCOntroller";
-    PlannedPerOrgUnitFragment plannedOrgUnitsFragment;
 
     public PlanModuleController(ModuleSettings moduleSettings) {
         super(moduleSettings);
@@ -61,27 +61,28 @@ public class PlanModuleController extends ModuleController {
     public void onOrgUnitSelected(String orgUnitUid) {
         Log.d(TAG, "onOrgUnitSelected");
 
-        if (plannedOrgUnitsFragment == null) {
-            plannedOrgUnitsFragment = new PlannedPerOrgUnitFragment();
-        }
+        fragment = new PlannedPerOrgUnitFragment();
+
         FragmentTransaction ft = getFragmentTransaction();
-        ft.replace(R.id.dashboard_planning_init, plannedOrgUnitsFragment);
-        ft.commit();
-        plannedOrgUnitsFragment.reloadData();
+        ft.replace(R.id.dashboard_planning_init, fragment);
+        ft.commitAllowingStateLoss();
+
+        if (orgUnitUid != null) {
+            ((IModuleFragment) fragment).reloadData();
+        }
+
     }
 
     public void onProgramSelected(String programUid) {
         Log.d(TAG, "onProgramSelected");
 
-        if (fragment == null) {
             fragment = PlannedFragment.newInstance(server.getClassification());
-        }
 
         FragmentTransaction ft = getFragmentTransaction();
         ft.replace(R.id.dashboard_planning_init, fragment);
-        ft.commit();
+        ft.commitAllowingStateLoss();
         if (programUid != null) {
-            ((PlannedFragment) fragment).reloadData();
+            ((IModuleFragment) fragment).reloadData();
         }
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
@@ -35,6 +35,7 @@ import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
 import org.eyeseetea.malariacare.domain.boundary.repositories.UserRepository;
 import org.eyeseetea.malariacare.domain.usecase.PushUseCase;
+import org.eyeseetea.malariacare.factories.AuthenticationFactory;
 import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.strategies.PushServiceStrategy;
@@ -85,7 +86,7 @@ public class PushService extends JobIntentService {
         ServerInfoRemoteDataSource serverInfoRemoteDataSource = new ServerInfoRemoteDataSource(
                 this);
         ServerInfoLocalDataSource serverInfoLocalDataSource = new ServerInfoLocalDataSource(this);
-        UserRepository userRepository = new UserD2ApiRepository();
+        UserRepository userRepository = AuthenticationFactory.INSTANCE.provideUserRepository();
         pushUseCase = new PushUseCase(pushController, mainExecutor, asyncExecutor,
                 new ServerInfoRepository(serverInfoLocalDataSource, serverInfoRemoteDataSource),
                 userRepository);


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/qtj71k
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: feature/top_crashlytics_crashes Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Analyze top crashes in Crashlytics and ty solve them.

### :memo: How is it being implemented?
- [x] Fix Retrofit.java line 454
- [x] Fix ActivityThread.java line 6026
- [x] Fix PlanModuleController.java line 69
- [x] Fix CreateSurveyFragment.java line 613, I have not reproduced this error but I have implemented a fix to avoid it

note: I have not reproduced OrgUnitProgramFilterPresenter.kt line 72 and without reproducing it I do not know how to make a fix

### :boom: How can it be tested?

- [ ] Enter in demo mode and should work
- [ ] Enter in the app and filer by org unit. Exit and enter again and should show plan module with the planned by org unit without any crash.

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots