### PR TITLE
Fix bug exporting database in devices from api 29

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/ExportData.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/ExportData.java
@@ -127,7 +127,9 @@ public class ExportData {
             FileWriter fw = new FileWriter(customInformation.getAbsoluteFile(), true);
             BufferedWriter bw = new BufferedWriter(fw);
             bw.write("Flavour: " + BuildConfig.FLAVOR + "\n");
-            bw.write(Session.getPhoneMetaData().getPhone_metaData() + "\n");
+            if (Session.getPhoneMetaData() != null){
+                bw.write(Session.getPhoneMetaData().getPhone_metaData() + "\n");
+            }
             bw.write("Version code: " + BuildConfig.VERSION_CODE + "\n");
             bw.write("Version name: " + BuildConfig.VERSION_NAME + "\n");
             bw.write("Aplication Id: " + BuildConfig.APPLICATION_ID + "\n");


### PR DESCRIPTION
### :pushpin: References
* **Issue:** 
* **Related pull-requests:**

###   :gear: branches 
**app**: 
       Origin: fix/export_database Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix export database

### :memo: How is it being implemented?

After testing in some devices, physical and emulator. the problem only occurs with devices with API greater than 28.
The problem is to create the txt file with metadata where we try insert IMEI data for example.
This data is not possible to retrieve from the device from Android 10.
https://source.android.com/devices/tech/config/device-identifiers

- [x] Fix export database from Android 10

### :boom: How can it be tested?

- [ ] Export database should work in old and new devices

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots