### PR TITLE
Remove lateinit for programs and orgUnits

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/OrgUnitProgramFilterPresenter.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/OrgUnitProgramFilterPresenter.kt
@@ -13,11 +13,11 @@ class OrgUnitProgramFilterPresenter(
 ) {
     internal var view: View? = null
 
-    private lateinit var programs: List<Program>
-    private lateinit var orgUnits: List<OrgUnit>
+    private var programs: List<Program> = listOf()
+    private var orgUnits: List<OrgUnit> = listOf()
 
-    private lateinit var programsNames: MutableList<String>
-    private lateinit var orgUnitsNames: MutableList<String>
+    private var programsNames: MutableList<String> = mutableListOf()
+    private var orgUnitsNames: MutableList<String> = mutableListOf()
 
     private var exclusiveFilter: Boolean = false
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/2c66ncc

###   :gear: branches 
**app**: 
       Origin: feature/fix_late_init_bugTarget: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix kotlin.UninitializedPropertyAccessException: lateinit property programs has not been initialized

### :memo: How is it being implemented?

I have not reproduced the error, but programs are loaded by use case then I think it's possible if the response is low that other methods where the program is used be invoked before programs are set. I have removed lateinit keyword and set it to an empty list by default.

- [x] remove lateinit from programs and org unit and set to empty list by default

### :boom: How can it be tested?


### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots