### PR TITLE
Fix null pointer exception to delete survey:

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/planning/SurveyPlanner.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/planning/SurveyPlanner.java
@@ -93,9 +93,13 @@ public class SurveyPlanner {
             } else {
                 newSurvey.resetMainScore();
             }
+
+            //Set as creationDate the completion date of the last survey
+            newSurvey.setCreationDate(lastSurveyScore.getCompletionDate());
+        } else {
+            //Set as creationDate the completion date of the last survey
+            newSurvey.setCreationDate(new Date());
         }
-        //Set as creationDate the completion date of the last survey
-        newSurvey.setCreationDate(lastSurveyScore.getCompletionDate());
 
         newSurvey.save();
         return newSurvey;


### PR DESCRIPTION
Fix null pointer exception to delete survey:
- When not exists last completion survey
- ### :pushpin: References
* **Issue:**  https://app.clickup.com/t/2c66ncc

###   :gear: branches 
**app**: 
       Origin: fix/fix_null_pointer_exception_to_delete_survey Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix null pointer exception error to try set creation date to new schedule survey after deleting a survey.

### :memo: How is it being implemented?

The bug is when not exist a last completion survey. In this case I set a current date

- [x] Fix null pointer exception setting creation date after deleting a survey.

### :boom: How can it be tested?

- Remove from de database all values
- Remove from the database all surveys with status != -1 (-1 status are scheduled surveys)
- Create a new survey but you don't complete it
- Remove in progress survey and any crash should occur

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots