### PR TITLE
Fix crash executing push after logout

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoadUserAndCredentialsUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoadUserAndCredentialsUseCase.java
@@ -54,8 +54,12 @@ public class LoadUserAndCredentialsUseCase {
         String password = sharedPreferences.getString(mContext.getString(R.string.dhis_password),
                 "");
 
-        Credentials credentials = new Credentials(serverURL, username, password);
+        if (!serverURL.isEmpty() && !username.isEmpty() && !password.isEmpty()){
+            Credentials credentials = new Credentials(serverURL, username, password);
 
-        Session.setCredentials(credentials);
+            Session.setCredentials(credentials);
+        } else {
+            Session.setCredentials(null);
+        }
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/strategies/PushServiceStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/strategies/PushServiceStrategy.java
@@ -26,6 +26,7 @@ import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.database.iomodules.dhis.exporter.PushDataController;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.Session;
+import org.eyeseetea.malariacare.domain.entity.Credentials;
 import org.eyeseetea.malariacare.domain.usecase.MockedPushSurveysUseCase;
 import org.eyeseetea.malariacare.domain.usecase.PushUseCase;
 import org.eyeseetea.malariacare.receivers.AlarmPushReceiver;
@@ -45,12 +46,18 @@ public class PushServiceStrategy {
     public void push(PushUseCase pushUseCase) {
         this.pushUseCase = pushUseCase;
 
-        if (Session.getCredentials().isDemoCredentials()) {
-            Log.d(TAG, "execute mocked push");
-            executeMockedPush();
+        final Credentials credentials = Session.getCredentials();
+
+        if (credentials != null){
+            if (credentials.isDemoCredentials()) {
+                Log.d(TAG, "execute mocked push");
+                executeMockedPush();
+            } else {
+                Log.d(TAG, "execute push");
+                executePush();
+            }
         } else {
-            Log.d(TAG, "execute push");
-            executePush();
+            Log.d(TAG, "Not execute push because credentials is null");
         }
     }
 


### PR DESCRIPTION
Fix null pointer exception to delete survey:
- When not exists last completion survey
- ### :pushpin: References
* **Issue:**  https://app.clickup.com/t/2c66nr9

###   :gear: branches 
**app**: 
       Origin: fix/crash_executing_push_from_logoutTarget: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix crash when push is executing during logout process and before cancel alarm

### :memo: How is it being implemented?

If load credentials is executed and shared preferences for url, user, and password are empty then set credentials to null in session. When from push service the credentials are retrieved from the session if credentials are null then not execute the push

- [x] Fix crash when push is executing during logout process and before cancel alarm 

### :boom: How can it be tested?

It's difficult to reproduce

- Execute logout at the same time the push is executed
- if the logout is executed first, the push should be cancel by alarm or null credentials

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots