### PR TITLE
Fix Parameter specified as non-null is null: crash

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/views/filters/OrgUnitProgramFilterView.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/filters/OrgUnitProgramFilterView.kt
@@ -136,7 +136,7 @@ class OrgUnitProgramFilterView(context: Context, attributeSet: AttributeSet) :
 
                 override fun onItemSelected(
                     parent: AdapterView<*>,
-                    view: View,
+                    view: View?,
                     position: Int,
                     id: Long
                 ) {


### PR DESCRIPTION
Fix null pointer exception to delete survey:
- When not exists last completion survey
- ### :pushpin: References
* **Issue:** 
 https://app.clickup.com/t/2c66nmm 
https://app.clickup.com/t/2c66p7y

###   :gear: branches 
**app**: 
       Origin: fix/crash_parameter_specified_as_non_null_is_null Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix crash `Fatal Exception: java.lang.NullPointerException: Parameter specified as non-null is null: method `

### :memo: How is it being implemented?

I have not reproduced the bug, but I have applied the solution that I have found here:
https://stackoverflow.com/a/45255651

- [x] Fix Parameter specified as non-null is null

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots