### PR TITLE
Fix NullPointerException to reload surveys if adapter is null

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
@@ -212,7 +212,7 @@ public class DashboardUnsentFragment extends FiltersFragment{
 
 
     public void reloadSurveys(List<SurveyDB> newListSurveys) {
-        if (newListSurveys != null) {
+        if (newListSurveys != null && this.adapter != null) {
             Log.d(TAG, "refreshScreen (Thread: " + Thread.currentThread().getId() + "): "
                     + newListSurveys.size());
             this.adapter.setSurveys(newListSurveys);


### PR DESCRIPTION
Fix null pointer exception to delete survey:
- When not exists last completion survey
- ### :pushpin: References
* **Issue:**  https://app.clickup.com/t/2c66nvy

###   :gear: branches 
**app**: 
       Origin: fix/crash_to_reload_surveys_if_adapter_null Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix NullPointerException to reload surveys if the adapter is null

### :memo: How is it being implemented?

I have not reproduced the bug, but the solution seems simple

- [x] Fix NullPointerException to reload surveys if the adapter is null

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots