### PR TITLE
Avoid NullPointerException to retrieve user attributtes

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/PullDhisApiDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/api/PullDhisApiDataSource.java
@@ -48,29 +48,32 @@ public class PullDhisApiDataSource {
     }
 
     public static UserDB pullUserAttributes(UserDB appUser) {
-        String lastMessage = appUser.getAnnouncement();
+        if (appUser != null) {
+            String lastMessage = appUser.getAnnouncement();
 
-        String data = USER + String.format(QUERY_USER_ATTRIBUTES, appUser.getUid());
-        Log.d(TAG, String.format("getUserAttributesApiCall(%s) -> %s", USER, data));
-        try {
-            Response response = executeCall(DHIS_PULL_API+data);
-            JsonNode jsonNode = parseResponse(response.body().string());
-            JsonNode jsonNodeArray = jsonNode.get(ATTRIBUTEVALUES);
-            String newMessage = "";
-            String closeDate = "";
-            for (int i = 0; i < jsonNodeArray.size(); i++) {
-                newMessage =
-                        getUserAnnouncement(jsonNodeArray, newMessage, i,
-                                UserDB.ATTRIBUTE_USER_ANNOUNCEMENT);
-                closeDate = getUserCloseDate(jsonNodeArray, closeDate, i);
+            String data = USER + String.format(QUERY_USER_ATTRIBUTES, appUser.getUid());
+            Log.d(TAG, String.format("getUserAttributesApiCall(%s) -> %s", USER, data));
+            try {
+                Response response = executeCall(DHIS_PULL_API + data);
+                JsonNode jsonNode = parseResponse(response.body().string());
+                JsonNode jsonNodeArray = jsonNode.get(ATTRIBUTEVALUES);
+                String newMessage = "";
+                String closeDate = "";
+                for (int i = 0; i < jsonNodeArray.size(); i++) {
+                    newMessage =
+                            getUserAnnouncement(jsonNodeArray, newMessage, i,
+                                    UserDB.ATTRIBUTE_USER_ANNOUNCEMENT);
+                    closeDate = getUserCloseDate(jsonNodeArray, closeDate, i);
+                }
+                saveNewAnnoucement(appUser, lastMessage, newMessage);
+                saveClosedDate(appUser, closeDate);
+
+            } catch (Exception ex) {
+                Log.e(TAG, "Cannot read user last updated from server with");
+                ex.printStackTrace();
             }
-            saveNewAnnoucement(appUser, lastMessage, newMessage);
-            saveClosedDate(appUser, closeDate);
-
-        } catch (Exception ex) {
-            Log.e(TAG, "Cannot read user last updated from server with");
-            ex.printStackTrace();
         }
+
         return appUser;
     }
 


### PR DESCRIPTION
- ### :pushpin: References
* **Issue:**  https://app.clickup.com/t/2c66pt8

###   :gear: branches 
**app**: 
       Origin: feature/avoid_null_pointer_exception_to_pull_user_attributtes Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix NullPointerException to retrieve user attributes

### :memo: How is it being implemented?

This bug is weird and I have not reproduced it because is produced after login and when the user is null to retrieve its attributes. I think is not possible in a normal process.
Anyway I have added a null protection 

- [x] Fix Avoid NullPointerException to retrieve user attributes

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots