### PR TITLE
Close cursor after to use it in migrations

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/migrations/Migration19AddCompetencyScoreClassificationSurveyColumn.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/migrations/Migration19AddCompetencyScoreClassificationSurveyColumn.java
@@ -38,23 +38,31 @@ public class Migration19AddCompetencyScoreClassificationSurveyColumn extends Bas
     }
 
     private void assignUIdToPlanSurveys(DatabaseWrapper database) {
-        Cursor planSurveysCursor = database.rawQuery(
-                "Select id_survey from Survey where status = -1 and uid_event_fk is null", null);
+        Cursor planSurveysCursor = null;
 
-        if (planSurveysCursor.moveToFirst()) {
+        try {
+            planSurveysCursor = database.rawQuery(
+                    "Select id_survey from Survey where status = -1 and uid_event_fk is null", null);
 
-            do {
+            if (planSurveysCursor.moveToFirst()) {
 
-                long surveyId = planSurveysCursor.getLong(0);
+                do {
 
-                String surveyUid = CodeGenerator.generateCode();
+                    long surveyId = planSurveysCursor.getLong(0);
 
-                database.execSQL(
-                        "UPDATE Survey set uid_event_fk = '" + surveyUid +
-                                "' where id_survey = " + surveyId);
+                    String surveyUid = CodeGenerator.generateCode();
 
-            } while (planSurveysCursor.moveToNext());
+                    database.execSQL(
+                            "UPDATE Survey set uid_event_fk = '" + surveyUid +
+                                    "' where id_survey = " + surveyId);
 
+                } while (planSurveysCursor.moveToNext());
+
+            }
+        } finally {
+            if (planSurveysCursor != null) {
+                planSurveysCursor.close();
+            }
         }
     }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/migrations/Migration20AddConnectedServerColumn.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/migrations/Migration20AddConnectedServerColumn.java
@@ -2,16 +2,12 @@ package org.eyeseetea.malariacare.data.database.migrations;
 
 import static org.eyeseetea.malariacare.data.database.migrations.MigrationUtils.addColumn;
 
-import android.database.Cursor;
-
 import com.raizlabs.android.dbflow.annotation.Migration;
 import com.raizlabs.android.dbflow.sql.migration.BaseMigration;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 import org.eyeseetea.malariacare.data.database.AppDatabase;
 import org.eyeseetea.malariacare.data.database.model.ServerDB;
-import org.eyeseetea.malariacare.data.database.model.SurveyDB;
-import org.hisp.dhis.client.sdk.core.common.utils.CodeGenerator;
 
 @Migration(version = 20, database = AppDatabase.class)
 public class Migration20AddConnectedServerColumn extends BaseMigration {


### PR DESCRIPTION
- ### :pushpin: References
* **Issue:**  https://app.clickup.com/t/2c66p2w

###   :gear: branches 
**app**: 
       Origin: fix/database_cursor_window_allocation_exception Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix data base CursorWindowAllocationException

### :memo: How is it being implemented?

This bug is complicated, It can be provoked by dbFlow, I have found some issues in the library GitHub
https://github.com/agrosner/DBFlow/issues/1642
https://github.com/agrosner/DBFlow/issues/1700

In the code where the bug is thrown, we don’t use a cursor directly, only we use dbflow models to query the database

```
public static ServerMetadataDB findControlDataElementByCode(String code){
    return new Select().from(ServerMetadataDB.class).where(ServerMetadataDB_Table.code.eq(code)).querySingle();
}
```

I have investigated this error and the problem seems related to memory usage and open database cursors.

We only use cursors directly in migrations. I don’t know if the problem is our cursors or internal dbflow cursors. I have reviewed our cursors in the migrations and someone is not closed after use.

We can try to close cursors in migrations where it’s not closed and review in the future if this bug appears again.

- [x] Close cursor after to use it in migrations

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots