### PR TITLE
Fix/late init bugs

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/OrgUnitProgramFilterPresenter.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/OrgUnitProgramFilterPresenter.kt
@@ -21,14 +21,14 @@ class OrgUnitProgramFilterPresenter(
 
     private var exclusiveFilter: Boolean = false
 
-    private lateinit var allOrgUnitText: String
-    private lateinit var allProgramsText: String
+    private var allOrgUnitText: String = ""
+    private var allProgramsText: String = ""
 
-    private lateinit var selectedProgramName: String
-    private lateinit var selectedOrgUnitName: String
+    private var selectedProgramName: String = ""
+    private var selectedOrgUnitName: String = ""
 
-    lateinit var selectedUidProgram: String
-    lateinit var selectedUidOrgUnit: String
+    var selectedUidProgram: String = ""
+    var selectedUidOrgUnit: String = ""
 
     fun attachView(view: View, allOrgUnitText: String, allProgramsText: String) {
         this.view = view

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/observations/ObservationsPresenter.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/observations/ObservationsPresenter.kt
@@ -56,6 +56,8 @@ class ObservationsPresenter(
         this.view = view
         this.surveyUid = surveyUid
 
+        observationViewModel = ObservationViewModel(surveyUid)
+
         loadData()
     }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/views/filters/OrgUnitProgramFilterView.kt
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/filters/OrgUnitProgramFilterView.kt
@@ -116,7 +116,7 @@ class OrgUnitProgramFilterView(context: Context, attributeSet: AttributeSet) :
 
                 override fun onItemSelected(
                     parent: AdapterView<*>,
-                    view: View,
+                    view: View?,
                     position: Int,
                     id: Long
                 ) {


### PR DESCRIPTION
- ### :pushpin: References
* **Issue:**  https://app.clickup.com/t/2f1w88u

###   :gear: branches 
**app**: 
       Origin: fix/late_init_bugs Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix data base CursorWindowAllocationException

### :memo: How is it being implemented?

I've not reproduced the bugs but I think the solutions are simple

- [x] Avoid late init bugs in OrgUnityProgramFilterPresenter
- [x] Avoid late init bugs in ObservationsPresenter

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots