### PR TITLE
Avoid NullPointerException in AlarmPushReceiver

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/receivers/AlarmPushReceiver.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/receivers/AlarmPushReceiver.java
@@ -110,10 +110,12 @@ public class AlarmPushReceiver extends BroadcastReceiver {
     public static void cancelPushAlarm(Context context) {
         Log.d(TAG, "cancelPushAlarm");
 
-        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        Intent intent = new Intent(context, AlarmPushReceiver.class);
-        PendingIntent sender = PendingIntent.getBroadcast(context, 0, intent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
-        alarmManager.cancel(sender);
+        if (context != null){
+            AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+            Intent intent = new Intent(context, AlarmPushReceiver.class);
+            PendingIntent sender = PendingIntent.getBroadcast(context, 0, intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT);
+            alarmManager.cancel(sender);
+        }
     }
 }


### PR DESCRIPTION
- ### :pushpin: References
* **Issue:** https://app.clickup.com/t/2f1w91j

###   :gear: branches 
**app**: 
       Origin: .fix/alarm_push_receiver_null_pointer_exception Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix NullPointerException in survey fragment

### :memo: How is it being implemented?

I've not reproduced this bug. Anyway I've added a validation to avoid NullPointerException

- [x] Avoid NullPointerException in AlarmPushReceiver

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots