### PR TITLE
Avoid IndexOutOfBoundsException if there are not org units

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/CreateSurveyFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/CreateSurveyFragment.java
@@ -182,7 +182,11 @@ public class CreateSurveyFragment extends Fragment {
         orgUnitListFirstLevel.add(0, orgUnitDefaultOption);
         viewHolder.component = llLayout.findViewById(R.id.org_unit);
         orgUnitView = (Spinner) viewHolder.component;
-        orgUnitView.setTag(orgUnitListFirstLevel.get(1).getOrgUnitLevel());
+
+        if (orgUnitListFirstLevel.size() > 1){
+            orgUnitView.setTag(orgUnitListFirstLevel.get(1).getOrgUnitLevel());
+        }
+
         orgUnitView.setAdapter(new OrgUnitArrayAdapter( getActivity(), orgUnitListFirstLevel));
         orgUnitView.setOnItemSelectedListener(new OrgUnitSpinnerListener(viewHolder));
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/3073kdm

###   :gear: branches 
**app**: 
       Origin: fix/avoid_index_out_of_bounds_exception_in_create_survey_fragmen Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fatal Exception: java.lang.IndexOutOfBoundsException: Index: 1, Size: 1

### :memo: How is it being implemented?

- [x] Avoid IndexOutOfBoundsException if there are not org units

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots