### PR TITLE
Avoid BadTokenException by memory leak

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/ProgressActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/ProgressActivity.java
@@ -102,8 +102,6 @@ public class ProgressActivity extends Activity {
     static Intent intent;
     public PullUseCase mPullUseCase;
     private Handler handler;
-    private ProgressActivity mProgressActivity;
-
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -123,7 +121,6 @@ public class ProgressActivity extends Activity {
         });
         intent = getIntent();
         handler = new Handler();
-        mProgressActivity = this;
     }
 
     private void initializeDependencies() {
@@ -208,7 +205,7 @@ public class ProgressActivity extends Activity {
     /**
      * Shows a dialog with the given message y move to login after showing error
      */
-    public void showException(final String msg) {
+    private void showException(final String msg) {
         Log.d(TAG, msg + " ");
 
         PULL_ERROR = true;
@@ -221,7 +218,7 @@ public class ProgressActivity extends Activity {
                 handler.post(new Runnable() { // This thread runs in the UI
                     @Override
                     public void run() {
-                        new AlertDialog.Builder(mProgressActivity)
+                        new AlertDialog.Builder(ProgressActivity.this)
                                 .setCancelable(false)
                                 .setTitle(dialogTitle)
                                 .setMessage(dialogMessage)
@@ -288,7 +285,7 @@ public class ProgressActivity extends Activity {
                 handler.post(new Runnable() { // This thread runs in the UI
                     @Override
                     public void run() {
-                        AlertDialog alertDialog = new AlertDialog.Builder(mProgressActivity)
+                        AlertDialog alertDialog = new AlertDialog.Builder(ProgressActivity.this)
                                 .setCancelable(false)
                                 .setTitle(title)
                                 .setMessage(msg)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/3073krx

###   :gear: branches 
**app**: 
       Origin: fix/avoid_bad_token_exception_progress_activity? Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix crash `Fatal Exception: android.view.WindowManager$BadTokenException: Unable to add window -- token android.os.BinderProxy@3419698 is not valid; is your activity running?`

### :memo: How is it being implemented?

I have not reproduced the bug after many tests but after analyze the code I think it's possible a memory leak error. I've modify the code to access to the activity to show dialog

- [x] Avoid BadTokenException

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots