### PR TITLE
Fix round bugs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,7 +127,7 @@ android {
         }
         hnqis {
             applicationId "org.eyeseetea.malariacare.hnqis_ng"
-            versionName "1.6.14"
+            versionName "1.6.15"
             buildConfigField "boolean", "translations", "true"
             buildConfigField "String", "defaultLocale", "\"en\""
             resValue "string", "authority", applicationId+versionName+"_DHIS2_DEFAULT_AUTHORITY"

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/feedback/CompositeScoreFeedback.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/feedback/CompositeScoreFeedback.java
@@ -21,6 +21,7 @@ package org.eyeseetea.malariacare.data.database.utils.feedback;
 
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.database.model.CompositeScoreDB;
+import org.eyeseetea.malariacare.utils.AUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -80,7 +81,7 @@ public class CompositeScoreFeedback implements Feedback {
      * @return The percentage as a String
      */
     public String getPercentageAsString(float idSurvey, String module){
-        return String.format("%.1f %%", getScore(idSurvey, module));
+        return AUtils.round(getScore(idSurvey, module),2);
     }
 
     /**

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/FeedbackFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/FeedbackFragment.java
@@ -49,6 +49,7 @@ import org.eyeseetea.malariacare.fragments.strategies.FeedbackFragmentStrategy;
 import org.eyeseetea.malariacare.layout.adapters.survey.FeedbackAdapter;
 import org.eyeseetea.malariacare.layout.utils.LayoutUtils;
 import org.eyeseetea.malariacare.services.SurveyService;
+import org.eyeseetea.malariacare.utils.AUtils;
 import org.eyeseetea.malariacare.utils.CompetencyUtils;
 import org.eyeseetea.malariacare.utils.Constants;
 import org.eyeseetea.malariacare.views.CustomButton;
@@ -224,7 +225,7 @@ public class FeedbackFragment extends Fragment implements IModuleFragment {
         if (survey.hasMainScore()) {
             float average = survey.getMainScoreValue();
             CustomTextView item = llLayout.findViewById(R.id.feedback_total_score);
-            item.setText(String.format("%.1f%%", average));
+            item.setText(AUtils.round(average,2));
             int colorId = LayoutUtils.trafficColor(average);
             mFeedbackFragmentStrategy.setTotalPercentColor(item, colorId, getActivity());
         } else {

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/ObservationsFragment.java
@@ -57,6 +57,7 @@ import org.eyeseetea.malariacare.presentation.viewmodels.observations.Observatio
 import org.eyeseetea.malariacare.presentation.viewmodels.observations.ActionViewModel;
 import org.eyeseetea.malariacare.presentation.views.CustomTextWatcher;
 import org.eyeseetea.malariacare.presentation.views.observations.ActionView;
+import org.eyeseetea.malariacare.utils.AUtils;
 import org.eyeseetea.malariacare.utils.CompetencyUtils;
 import org.eyeseetea.malariacare.utils.DateParser;
 import org.eyeseetea.malariacare.views.CustomEditText;
@@ -313,7 +314,7 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
         renderLabelHeaderByServerClassification(serverClassification, classification);
 
         if (mainScore > 0f) {
-            mTotalScoreTextView.setText(String.format("%.1f%%", mainScore));
+            mTotalScoreTextView.setText(AUtils.round(mainScore,2));
             int colorId = LayoutUtils.trafficColor(mainScore);
             mTotalScoreTextView.setBackgroundColor(getResources().getColor(colorId));
         } else {
@@ -450,7 +451,7 @@ public class ObservationsFragment extends Fragment implements IModuleFragment,
                     + competencyText + "\n";
         }
 
-        int roundedScore = Math.round(survey.getMainScoreValue());
+        float roundedScore = Float.parseFloat(AUtils.round(survey.getMainScoreValue(),2));
         data += getString(R.string.quality_of_care).toUpperCase() + ": " + roundedScore + "% \n";
 
         data += String.format(getString(R.string.plan_action_next_date), formattedNextScheduleDate);

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/dashboard/AssessmentSentAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/dashboard/AssessmentSentAdapter.java
@@ -32,6 +32,7 @@ import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 import org.eyeseetea.malariacare.domain.entity.ServerClassification;
+import org.eyeseetea.malariacare.utils.AUtils;
 import org.eyeseetea.malariacare.utils.CompetencyUtils;
 import org.eyeseetea.malariacare.utils.DateParser;
 import org.eyeseetea.malariacare.views.CustomTextView;
@@ -41,9 +42,6 @@ import java.util.Date;
 import java.util.List;
 
 public class AssessmentSentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>  {
-
-    public static final String SCORE_FORMAT = "%.1f %%";
-
     List<SurveyDB> surveys = new ArrayList<>();
     ServerClassification classification;
 
@@ -131,7 +129,7 @@ public class AssessmentSentAdapter extends RecyclerView.Adapter<RecyclerView.Vie
                     CompetencyUtils.setTextByCompetencyAbbreviation(classificationTextView, classification);
                 } else {
                     if (survey.hasMainScore()){
-                        String value = Math.round(survey.getMainScoreValue()) + " %";
+                        String value = AUtils.round(survey.getMainScoreValue(),2) + " %";
                         classificationTextView.setText(value);
                     } else {
                         classificationTextView.setText("-");

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/monitor/SurveysMonitorAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/monitor/SurveysMonitorAdapter.java
@@ -13,6 +13,7 @@ import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.domain.entity.CompetencyScoreClassification;
 import org.eyeseetea.malariacare.domain.entity.ScoreType;
 import org.eyeseetea.malariacare.domain.entity.ServerClassification;
+import org.eyeseetea.malariacare.utils.AUtils;
 import org.eyeseetea.malariacare.utils.CompetencyUtils;
 import org.eyeseetea.malariacare.utils.DateParser;
 
@@ -89,7 +90,7 @@ public class SurveysMonitorAdapter extends RecyclerView.Adapter<RecyclerView.Vie
             DateParser dateParser = new DateParser();
             completionDateView.setText(
                     dateParser.getEuropeanFormattedDate(survey.getCompletionDate()));
-            scoreView.setText(Math.round(survey.getMainScoreValue()) + "");
+            scoreView.setText(AUtils.round(survey.getMainScoreValue(), 2) + "");
             Resources resources = itemView.getContext().getResources();
 
             ScoreType scoreType = new ScoreType(survey.getMainScoreValue());

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/CompositeScoreAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/CompositeScoreAdapter.java
@@ -80,7 +80,7 @@ public class CompositeScoreAdapter extends ATabAdapter {
         if (compositeScoreValue == null)
             ((CustomTextView)rowView.findViewById(R.id.score)).setText(getContext().getString(R.string.number_zero));
         else
-            ((CustomTextView)rowView.findViewById(R.id.score)).setText(AUtils.round(compositeScoreValue));
+            ((CustomTextView)rowView.findViewById(R.id.score)).setText(AUtils.round(compositeScoreValue,2));
 
         rowView.setBackgroundResource(LayoutUtils.calculateBackgrounds(position));
 

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/DashboardController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/dashboard/controllers/DashboardController.java
@@ -618,7 +618,7 @@ public class DashboardController {
             String qoC = dashboardActivity.getString(R.string.overall_quality_of_care) + ": ";
 
             if (survey.hasMainScore()) {
-                qoC = qoC + AUtils.round(survey.getMainScore().getScore()) + " %";
+                qoC = qoC + AUtils.round(survey.getMainScore().getScore(),2) + " %";
             } else {
                 qoC = qoC + "-";
             }

--- a/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/monitoring/MonitorBySurveyActionsPresenter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/presentation/presenters/monitoring/MonitorBySurveyActionsPresenter.java
@@ -153,7 +153,7 @@ public class MonitorBySurveyActionsPresenter {
         String qualityOfCare = "-";
 
         if (survey.getScore() != null) {
-            qualityOfCare = AUtils.round(survey.getScore().getScore()) + " %";
+            qualityOfCare = AUtils.round(survey.getScore().getScore(), 2) + " %";
         }
 
         return new SurveyViewModel(survey.getSurveyUid(), programName, orgUnitName,

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/AUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/AUtils.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
@@ -61,10 +62,13 @@ import java.util.List;
 
 public abstract class AUtils {
     public static String round(float base, int decimalPlace) {
-        BigDecimal bd = new BigDecimal(Float.toString(base));
-        bd = bd.setScale(decimalPlace, BigDecimal.ROUND_HALF_EVEN);
-        if (decimalPlace == 0) return Integer.toString((int) bd.floatValue());
-        return Float.toString(bd.floatValue());
+        String numberSigns = "";
+        for (int i = 0; i < decimalPlace; i++) {
+            numberSigns += "0";
+        }
+
+        DecimalFormat df = new DecimalFormat("0." + numberSigns);
+        return df.format(base);
     }
 
     public static float safeParseFloat(String floatStr) {

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/AUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/AUtils.java
@@ -60,12 +60,9 @@ import java.util.Iterator;
 import java.util.List;
 
 public abstract class AUtils {
-
-    private static final int ZERO_DECIMALS = 0; // Number of decimals outputs will have
-
     public static String round(float base, int decimalPlace) {
         BigDecimal bd = new BigDecimal(Float.toString(base));
-        bd = bd.setScale(decimalPlace, BigDecimal.ROUND_HALF_UP);
+        bd = bd.setScale(decimalPlace, BigDecimal.ROUND_HALF_EVEN);
         if (decimalPlace == 0) return Integer.toString((int) bd.floatValue());
         return Float.toString(bd.floatValue());
     }
@@ -78,10 +75,6 @@ public abstract class AUtils {
                     String.format("Error when parsing string %s to float number", floatStr));
             return 0f;
         }
-    }
-
-    public static String round(float base) {
-        return round(base, AUtils.ZERO_DECIMALS);
     }
 
     public static List<BaseModel> convertTabToArrayCustom(TabDB tab) {

--- a/app/src/test/java/org/eyeseetea/malariacare/utils/AUtilsShould.java
+++ b/app/src/test/java/org/eyeseetea/malariacare/utils/AUtilsShould.java
@@ -1,0 +1,36 @@
+package org.eyeseetea.malariacare.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import org.junit.Test;
+
+public class AUtilsShould {
+
+    @Test
+    public void return_always_two_decimals_if_both_are_zero() {
+        String value = AUtils.round(12.00283848f, 2);
+
+        assertThat(value, is("12.00"));
+    }
+
+    @Test
+    public void return_always_two_decimals_if_one_is_0() {
+        String value = AUtils.round(12.20398398f, 2);
+
+        assertThat(value, is("12.20"));
+    }
+
+    @Test
+    public void return_always_two_decimals_to_0_value() {
+        String value = AUtils.round(0f, 2);
+
+        assertThat(value, is("0.00"));
+    }
+
+    @Test
+    public void return_always_two_decimals_if_does_not_exit_0() {
+        String value = AUtils.round(34.5848586f, 2);
+
+        assertThat(value, is("34.58"));
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
             minSdkVersion    : 16,
             compileSdkVersion: 31,
             targetSdkVersion : 31,
-            versionCode      : 76,
+            versionCode      : 77,
             versionName      : "QAApp"
     ]
     libraries = [


### PR DESCRIPTION
- ### :pushpin: References
* **Issue:** https://app.clickup.com/t/3dejg1f

###   :gear: branches 
**app**: 
       Origin: fix/round_score_decimals Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix rounds to 2 decimals.

Places where should appear.

- Planned surveys (if server classification is scoring)
- plannedModelDialog (if server classification is scoring)
- Survey - tab score (when tab isGeneralScore)
- Monitoring graph (if server classification is scoring)
- Monitoring graph dialog (if server classification is scoring)
- Monitoring by survey actions (if server classification is scoring)
- Feedback
- Observations (if server classification is scoring)
- Share Observations (if server classification is scoring)
- Sent surveys  (if server classification is scoring)

### :memo: How is it being implemented?

- [x] Fix round bugs


### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots