### PR TITLE
Hide button but maintaining the space.

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
@@ -111,7 +111,7 @@ public class DashboardUnsentFragment extends FiltersFragment implements SurveysP
             noSurveysText.setText(R.string.assess_no_surveys);
         } else if (survey != null ||
                 !OrgUnitProgramRelationDB.existProgramAndOrgUnitRelation(programFilter, orgUnitFilter)) {
-            createSurveyButton.hide();
+            ((View)createSurveyButton).setVisibility(View.INVISIBLE);
             noSurveysText.setText(R.string.survey_not_assigned_facility);
         } else {
             createSurveyButton.show();


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/860qy9f7p
* related PR * 

###   :gear: branches 
**app**: 
       Origin: fix/overlapsed_text_in_assessment_when_no_survey_is_found  Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix overlapped text

### :memo: How is it being implemented?

- [x] - Fix overlapped text

- From Android P you cannot use setVisibility directly. After investigating, the recommended approach is to use show o hide methods but there is no equivalent for set visibility to invisible VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=com.google.android.material from groupId=malariapp)

I use a hack to convert the fab to view

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots