### PR TITLE
Remove duplicate no surveys message

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorFragment.java
@@ -163,11 +163,6 @@ public class MonitorFragment extends FiltersFragment implements IModuleFragment,
         this.filterType = monitorFilter;
     }
 
-    private void showMessageNoAddedSurveys(boolean show) {
-        getActivity().findViewById(R.id.monitor_no_surveys_message).setVisibility(
-                show ? View.VISIBLE : View.GONE);
-    }
-
     public void reloadMonitor(List<Survey> surveys, Map<String, Program> programs, Map<String, OrgUnit> orgUnits) {
         webView = initMonitor();
         //onPageFinish load data
@@ -320,12 +315,6 @@ public class MonitorFragment extends FiltersFragment implements IModuleFragment,
     public void showData(@NotNull List<Survey> surveys,
                          @NotNull Map<String, Program> programs,
                          @NotNull Map<String, OrgUnit> orgUnits) {
-        if (surveys.size() == 0) {
-            showMessageNoAddedSurveys(true);
-        } else {
-            showMessageNoAddedSurveys(false);
-
             reloadMonitor(surveys, programs, orgUnits);
-        }
     }
 }

--- a/app/src/main/res/layout/fragment_monitor_by_calendar.xml
+++ b/app/src/main/res/layout/fragment_monitor_by_calendar.xml
@@ -10,12 +10,4 @@
         android:focusable="true"
         >
     </WebView>
-
-    <TextView
-        android:id="@+id/monitor_no_surveys_message"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:text="@string/monitor_no_surveys_to_show"
-        android:visibility="gone" />
 </RelativeLayout>


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/860qy9ey2
* related PR **

###   :gear: branches 
**app**: 
       Origin: fix/duplicated_label_when_no_there_is_no_survey_to_display  Target: v1.6_hnqis
**bugshaker-android**: 
       Origin: development_android_x  
**EyeSeeTea-SDK**: 
       Origin: feature/development 
**SDK**: 
       Origin: feature-2.30_upgrade_gradle

### :tophat: What is the goal?

Fix duplicated label when no there is no survey to display

### :memo: How is it being implemented?

- [x] - Remove duplicate label

### :boom: How can it be tested?

### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots